### PR TITLE
Move norm_id into representation

### DIFF
--- a/src/indra_cogex/neo4j_client.py
+++ b/src/indra_cogex/neo4j_client.py
@@ -10,8 +10,7 @@ from neo4j import GraphDatabase
 from indra.databases import identifiers
 from indra.statements import Agent
 from indra.ontology.standardize import get_standard_agent
-from indra_cogex.representation import Node, Relation
-from indra_cogex.sources.processor import norm_id
+from indra_cogex.representation import Node, Relation, norm_id
 
 logger = logging.getLogger(__name__)
 

--- a/src/indra_cogex/representation.py
+++ b/src/indra_cogex/representation.py
@@ -6,6 +6,8 @@ from typing import Any, Collection, Mapping, Optional
 
 __all__ = ["Node", "Relation"]
 
+from indra.databases import identifiers
+
 
 class Node:
     """Representation for a node."""
@@ -114,3 +116,17 @@ class Relation:
 
     def __repr__(self):  # noqa:D105
         return str(self)
+
+
+def norm_id(db_ns, db_id):
+    identifiers_ns = identifiers.get_identifiers_ns(db_ns)
+    identifiers_id = db_id
+    if not identifiers_ns:
+        identifiers_ns = db_ns.lower()
+    else:
+        ns_embedded = identifiers.identifiers_registry.get(identifiers_ns, {}).get(
+            "namespace_embedded"
+        )
+        if ns_embedded:
+            identifiers_id = identifiers_id[len(identifiers_ns) + 1 :]
+    return f"{identifiers_ns}:{identifiers_id}"

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -14,10 +14,9 @@ import pystow
 from more_click import verbose_option
 from tqdm import tqdm
 
-from indra.databases import identifiers
 from indra.statements.validate import assert_valid_db_refs
 
-from indra_cogex.representation import Node, Relation
+from indra_cogex.representation import Node, Relation, norm_id
 
 __all__ = [
     "Processor",
@@ -144,20 +143,6 @@ class Processor(ABC):
             # Write remaining edges
             edge_writer.writerows(edge_rows)
         return self.edges_path
-
-
-def norm_id(db_ns, db_id):
-    identifiers_ns = identifiers.get_identifiers_ns(db_ns)
-    identifiers_id = db_id
-    if not identifiers_ns:
-        identifiers_ns = db_ns.lower()
-    else:
-        ns_embedded = identifiers.identifiers_registry.get(identifiers_ns, {}).get(
-            "namespace_embedded"
-        )
-        if ns_embedded:
-            identifiers_id = identifiers_id[len(identifiers_ns) + 1 :]
-    return f"{identifiers_ns}:{identifiers_id}"
 
 
 def validate_nodes(nodes):

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,4 +1,4 @@
-from indra_cogex.sources.processor import norm_id
+from indra_cogex.representation import norm_id
 
 
 def test_norm_id():


### PR DESCRIPTION
This PR moves the `norm_id` function into the `representation` module. This makes the `neo4j_client` independent of the source modules resulting in easier reuse.