### PR TITLE
Add more metadata to INDRA edges

### DIFF
--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -85,6 +85,7 @@ class DbProcessor(Processor):
             yield Node(db_ns, db_id, ["BioEntity"], dict(name=name))
 
     def get_relations(self):  # noqa:D102
+        rel_type = "indra_rel"
         columns = [
             "agA_ns",
             "agA_id",
@@ -92,7 +93,8 @@ class DbProcessor(Processor):
             "agB_id",
             "stmt_type",
             "source_counts",
-            "ev_count",
+            "evidence_count",
+            "belief",
             "stmt_hash",
         ]
         for (
@@ -102,6 +104,8 @@ class DbProcessor(Processor):
             target_id,
             stmt_type,
             source_counts,
+            evidence_count,
+            belief,
             stmt_hash,
         ) in (
             self.df[columns].drop_duplicates().values
@@ -109,14 +113,16 @@ class DbProcessor(Processor):
             data = {
                 "stmt_hash:long": stmt_hash,
                 "source_counts:string": source_counts,
-                "ev_count:int": sum(source_counts.values()),
+                "evidence_count:int": evidence_count,
+                "stmt_type:string": stmt_type,
+                "belief:float": belief,
             }
             yield Relation(
                 source_ns,
                 source_id,
                 target_ns,
                 target_id,
-                stmt_type,
+                rel_type,
                 data,
             )
 

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -92,6 +92,7 @@ class DbProcessor(Processor):
             "agB_id",
             "stmt_type",
             "source_counts",
+            "ev_count",
             "stmt_hash",
         ]
         for (
@@ -105,7 +106,11 @@ class DbProcessor(Processor):
         ) in (
             self.df[columns].drop_duplicates().values
         ):
-            data = {"stmt_hash:long": stmt_hash, "source_counts:string": source_counts}
+            data = {
+                "stmt_hash:long": stmt_hash,
+                "source_counts:string": source_counts,
+                "ev_count:int": sum(source_counts.values()),
+            }
             yield Relation(
                 source_ns,
                 source_id,

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -142,5 +142,7 @@ def fix_id(db_ns: str, db_id: str) -> Tuple[str, str]:
         db_ns = "UPLOC"
     if db_ns == "UP" and "-" in db_id and not db_id.startswith("SL-"):
         db_id = db_id.split("-")[0]
+    if db_ns == "FPLX" and db_id == "TCF-LEF":
+        db_id = "TCF_LEF"
     db_id = ensure_prefix_if_needed(db_ns, db_id)
     return db_ns, db_id

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -35,7 +35,11 @@ class DbProcessor(Processor):
     def __init__(self, path: Union[None, str, Path] = None):
         """Initialize the INDRA database processor.
 
-        :param path: The path to the INDRA database SIF dump pickle. If none given, will look in the default location.
+        Parameters
+        ----------
+        path :
+            The path to the INDRA database SIF dump pickle. If none given,
+            will look in the default location.
         """
         if path is None:
             path = pystow.join("indra", "db", name="sif.pkl")


### PR DESCRIPTION
This PR adds the evidence count to INDRA edges. @cthoyt I wonder if we should make a bigger change here. Namely, we might want to change the approach of using `stmt_type` as the Relation's type corresponding to INDRA Statement. The reason is that for various path/pattern queries, we want to be able to traverse _any_ INDRA Statement edge, and currently we'd have to enumerate all statement types explicitly to be able to do that.