### PR TITLE
Improvements to loading sources

### DIFF
--- a/import.sh
+++ b/import.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-SUDO=false
+SUDO=false  # Set to true to run as sudo
 
 
-if [ SUDO = true ]
+if [[ $SUDO == "true" ]]
 then
    NEO4J_PREFIX="sudo"
    COGEX_SUDO_ARG="--with-sudo"
@@ -25,12 +25,12 @@ echo "NEO4J_DATA=$NEO4J_DATA"
 # Output commands as you go
 set -x
 
-$PREFIX neo4j stop
-rm import.report
+$NEO4J_PREFIX neo4j stop
+$NEO4J_PREFIX rm import.report
 
 # Delete the old database and associated transactions
-rm -rf $NEO4J_DATA/databases/indra
-$PREFIX rm -rf $NEO4J_DATA/transactions/indra
+$NEO4J_PREFIX rm -rf $NEO4J_DATA/databases/indra
+$NEO4J_PREFIX rm -rf $NEO4J_DATA/transactions/indra
 
 # Just show what it is. This should match the --database option used below
 cat $NEO4J_CONFIG/neo4j.conf | grep "dbms\.default_database"
@@ -38,4 +38,4 @@ cat $NEO4J_CONFIG/neo4j.conf | grep "dbms\.default_database"
 
 python -m indra_cogex.sources --load $SUDO_ARG
 
-$PREFIX neo4j start
+$NEO4J_PREFIX neo4j start

--- a/import.sh
+++ b/import.sh
@@ -36,6 +36,6 @@ $NEO4J_PREFIX rm -rf $NEO4J_DATA/transactions/indra
 cat $NEO4J_CONFIG/neo4j.conf | grep "dbms\.default_database"
 
 
-python -m indra_cogex.sources --load $SUDO_ARG
+python -m indra_cogex.sources --load $COGEX_SUDO_ARG
 
 $NEO4J_PREFIX neo4j start

--- a/import.sh
+++ b/import.sh
@@ -1,21 +1,41 @@
 #!/usr/bin/env bash
+SUDO=false
+
+
+if [ SUDO = true ]
+then
+   NEO4J_PREFIX="sudo"
+   COGEX_SUDO_ARG="--with-sudo"
+else
+   NEO4J_PREFIX=""
+   COGEX_SUDO_ARG=""
+fi
+
+echo "NEO4J_PREFIX=$NEO4J_PREFIX"
+echo "COGEX_SUDO_ARG=$COGEX_SUDO_ARG"
+
+
 # NEO4J_VERSION=$(neo4j version | cut -f 2 -d ' ')
-NEO4J_CONFIG=$(neo4j console | grep "^\s*config" | sed 's/^[ \t]*config:[ \t]*//g')
-NEO4J_DATA=$(neo4j console | grep "^\s*data" | sed 's/^[ \t]*data:[ \t]*//g')
+NEO4J_CONFIG=$($NEO4J_PREFIX neo4j console | grep "^\s*config" | sed 's/^[ \t]*config:[ \t]*//g')
+NEO4J_DATA=$($NEO4J_PREFIX neo4j console | grep "^\s*data" | sed 's/^[ \t]*data:[ \t]*//g')
+
+echo "NEO4J_CONFIG=$NEO4J_CONFIG"
+echo "NEO4J_DATA=$NEO4J_DATA"
 
 # Output commands as you go
 set -x
 
-neo4j stop
+$PREFIX neo4j stop
 rm import.report
 
 # Delete the old database and associated transactions
 rm -rf $NEO4J_DATA/databases/indra
-rm -rf $NEO4J_DATA/transactions/indra
+$PREFIX rm -rf $NEO4J_DATA/transactions/indra
 
 # Just show what it is. This should match the --database option used below
 cat $NEO4J_CONFIG/neo4j.conf | grep "dbms\.default_database"
 
-python -m indra_cogex.sources --load
 
-neo4j start
+python -m indra_cogex.sources --load $SUDO_ARG
+
+$PREFIX neo4j start

--- a/src/indra_cogex/__init__.py
+++ b/src/indra_cogex/__init__.py
@@ -1,0 +1,1 @@
+from indra import logger

--- a/src/indra_cogex/neo4j_client.py
+++ b/src/indra_cogex/neo4j_client.py
@@ -435,12 +435,33 @@ class Neo4jClient:
         relation :
             A Relation object with the INDRA standard identifier scheme.
         """
-        neo4j_relation = neo4j_path.relationships[0]
-        rel_type = neo4j_relation.type
-        props = dict(neo4j_relation)
-        source_ns, source_id = process_identifier(neo4j_relation.start_node["id"])
-        target_ns, target_id = process_identifier(neo4j_relation.end_node["id"])
-        return Relation(source_ns, source_id, target_ns, target_id, rel_type, props)
+        return Neo4jClient.neo4j_to_relations(neo4j_path)[0]
+
+    @staticmethod
+    def neo4j_to_relations(neo4j_path: neo4j.graph.Path) -> List[Relation]:
+        """Return a Relation from a neo4j internal single-relation path.
+
+        Parameters
+        ----------
+        neo4j_path :
+            A neo4j internal single-edge path using its internal data structure
+            and identifier scheme.
+
+        Returns
+        -------
+        :
+            A list of Relation objects with the INDRA standard identifier
+            scheme.
+        """
+        relations = []
+        for neo4j_relation in neo4j_path.relationships:
+            rel_type = neo4j_relation.type
+            props = dict(neo4j_relation)
+            source_ns, source_id = process_identifier(neo4j_relation.start_node["id"])
+            target_ns, target_id = process_identifier(neo4j_relation.end_node["id"])
+            rel = Relation(source_ns, source_id, target_ns, target_id, rel_type, props)
+            relations.append(rel)
+        return relations
 
     @staticmethod
     def node_to_agent(node: Node) -> Agent:

--- a/src/indra_cogex/sources/__init__.py
+++ b/src/indra_cogex/sources/__init__.py
@@ -9,6 +9,12 @@ from .goa import GoaProcessor
 from .indra_db import DbProcessor
 from .indra_ontology import OntologyProcessor
 from .pathways import ReactomeProcessor, WikipathwaysProcessor
+from .cbioportal import (
+    CcleCnaProcessor,
+    CcleMutationsProcessor,
+    CcleDrugResponseProcessor,
+)
+from .clinicaltrials import ClinicaltrialsProcessor
 from .processor import Processor
 
 __all__ = [
@@ -20,6 +26,10 @@ __all__ = [
     "GoaProcessor",
     "DbProcessor",
     "OntologyProcessor",
+    "CcleCnaProcessor",
+    "CcleMutationsProcessor",
+    "CcleDrugResponseProcessor",
+    "ClinicaltrialsProcessor",
 ]
 
 processor_resolver = Resolver.from_subclasses(Processor)

--- a/src/indra_cogex/sources/cli.py
+++ b/src/indra_cogex/sources/cli.py
@@ -50,6 +50,7 @@ def main(load: bool, load_only: bool, force: bool, with_sudo: bool):
             if (
                 force
                 or not processor_cls.nodes_path.is_file()
+                or not processor_cls.nodes_indra_path.is_file()
                 or not processor_cls.edges_path.is_file()
             ):
                 processor = processor_cls()

--- a/src/indra_cogex/sources/cli.py
+++ b/src/indra_cogex/sources/cli.py
@@ -31,8 +31,13 @@ from ..assembly import NodeAssembler
     is_flag=True,
     help="If true, rebuild all resources",
 )
+@click.option(
+    "--with_sudo",
+    is_flag=True,
+    help="If true, sudo is prepended to the neo4j-admin import command",
+)
 @verbose_option
-def main(load: bool, load_only: bool, force: bool):
+def main(load: bool, load_only: bool, force: bool, with_sudo: bool):
     """Generate and import Neo4j nodes and edges tables."""
     paths = []
     na = NodeAssembler()
@@ -64,9 +69,10 @@ def main(load: bool, load_only: bool, force: bool):
             Processor._dump_nodes_to_path(assembled_nodes, nodes_path)
 
     if load or load_only:
+        sudo_prefix = "" if not with_sudo else "sudo"
         command = dedent(
             f"""\
-        neo4j-admin import \\
+        {sudo_prefix} neo4j-admin import \\
           --database=indra \\
           --delimiter='TAB' \\
           --skip-duplicate-nodes=true \\

--- a/src/indra_cogex/sources/clinicaltrials/__init__.py
+++ b/src/indra_cogex/sources/clinicaltrials/__init__.py
@@ -98,9 +98,13 @@ class ClinicaltrialsProcessor(Processor):
             yield Node(db_ns="CLINICALTRIALS", db_id=nctid, labels=[])
 
     def get_relations(self):
+        added = set()
         for cond_ns, cond_id, target_id in zip(
             self.has_trial_cond_ns, self.has_trial_cond_id, self.has_trial_nct
         ):
+            if (cond_ns, cond_id, target_id) in added:
+                continue
+            added.add((cond_ns, cond_id, target_id))
             yield Relation(
                 source_ns=cond_ns,
                 source_id=cond_id,
@@ -108,9 +112,13 @@ class ClinicaltrialsProcessor(Processor):
                 target_id=target_id,
                 rel_type="has_trial",
             )
+        added = set()
         for int_ns, int_id, target_id in zip(
             self.tested_in_int_ns, self.tested_in_int_id, self.tested_in_nct
         ):
+            if (int_ns, int_id, target_id) in added:
+                continue
+            added.add((int_ns, int_id, target_id))
             yield Relation(
                 source_ns=int_ns,
                 source_id=int_id,

--- a/src/indra_cogex/sources/pathways/__init__.py
+++ b/src/indra_cogex/sources/pathways/__init__.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 from indra.databases import hgnc_client
 from indra.databases import uniprot_client
 from indra.databases.identifiers import get_ns_id_from_identifiers
+from indra.ontology.bio import bio_ontology
 import pyobo
 import pyobo.api.utils
 from pyobo.struct import has_part
@@ -48,6 +49,9 @@ class PyoboProcessor(Processor):
             pathway_ns, pathway_id = get_ns_id_from_identifiers(self.prefix, identifier)
             gene_ns, gene_id = self.get_gene(t_prefix, t_identifier)
             if not gene_ns:
+                continue
+            # This is to skip e.g., unreviewed non-human proteins
+            if not bio_ontology.get_name(gene_ns, gene_id):
                 continue
             yield Relation(
                 pathway_ns,

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -5,6 +5,7 @@
 import csv
 import gzip
 import logging
+import pickle
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import ClassVar, Iterable
@@ -38,6 +39,7 @@ class Processor(ABC):
     module: ClassVar[pystow.Module]
     directory: ClassVar[Path]
     nodes_path: ClassVar[Path]
+    nodes_indra_path: ClassVar[Path]
     edges_path: ClassVar[Path]
     importable = True
 
@@ -45,7 +47,11 @@ class Processor(ABC):
         """Initialize the class attributes."""
         cls.module = pystow.module("indra", "cogex", cls.name)
         cls.directory = cls.module.base
+        # These are nodes directly in the neo4j encoding
         cls.nodes_path = cls.module.join(name="nodes.tsv.gz")
+        # These are nodes in the original INDRA-oriented representation
+        # needed for assembly
+        cls.nodes_indra_path = cls.module.join(name="nodes.pkl")
         cls.edges_path = cls.module.join(name="edges.tsv.gz")
 
     @abstractmethod
@@ -83,6 +89,8 @@ class Processor(ABC):
     def _dump_nodes(self) -> Path:
         sample_path = self.module.join(name="nodes_sample.tsv")
         nodes = sorted(self.get_nodes(), key=lambda x: (x.db_ns, x.db_id))
+        with open(self.nodes_indra_path, "wb") as fh:
+            pickle.dump(nodes, fh)
         return self._dump_nodes_to_path(nodes, self.nodes_path, sample_path)
 
     @staticmethod


### PR DESCRIPTION
This PR makes a number of improvements related to loading sources:
- Add new sources missing from the overall import process
- Allow parameterizing the import script to use sudo which is necessary in some environments
- Cache Nodes in native representation to allow node assembly across all sources even if a given source isn't reprocessed
- Eliminate duplicate relations from clinical trials
- Eliminate some unreviewed non-human proteins from pathway membership
- Use a configured logger