### PR TITLE
Add processors for drug indications and side effects

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     pystow>=0.1.6
     pyobo
     gilda
+    biomappings
 
 include_package_data = True
 python_requires = >=3.6

--- a/src/indra_cogex/representation.py
+++ b/src/indra_cogex/representation.py
@@ -7,7 +7,7 @@ from typing import Any, Collection, Mapping, Optional, Tuple
 __all__ = ["Node", "Relation"]
 
 from indra.databases import identifiers
-from indra.ontology.standardize import get_standard_name, standardize_db_refs
+from indra.ontology.standardize import standardize_name_db_refs
 from indra.statements.agent import get_grounding
 
 
@@ -142,11 +142,11 @@ def standardize(
     prefix: str, identifier: str, name: Optional[str] = None
 ) -> Tuple[str, str, str]:
     """Get a standardized prefix, identifier, and name, if possible."""
-    db_refs = standardize_db_refs({prefix: identifier})
+    db_refs, standard_name = standardize_name_db_refs({prefix: identifier})
+    name = standard_name if standard_name else name
     db_ns, db_id = get_grounding(db_refs)
     if db_ns is None or db_id is None:
         return prefix, identifier, name
-    name = get_standard_name(db_refs) or name
     return db_ns, db_id, name
 
 

--- a/src/indra_cogex/representation.py
+++ b/src/indra_cogex/representation.py
@@ -42,6 +42,24 @@ class Node:
         self.labels = labels
         self.data = data if data else {}
 
+    @classmethod
+    def standardized(
+        cls,
+        *,
+        db_ns: str,
+        db_id: str,
+        name: Optional[str] = None,
+        labels: Collection[str],
+    ) -> "Node":
+        """Initialize the node, but first standardize the prefix/identifier/name."""
+        db_ns, db_id, name = standardize(db_ns, db_id, name)
+        return cls(
+            db_ns,
+            db_id,
+            labels,
+            dict(name=name),
+        )
+
     def to_json(self):
         """Serialize the node to JSON."""
         data = {k: v for k, v in self.data.items()}

--- a/src/indra_cogex/representation.py
+++ b/src/indra_cogex/representation.py
@@ -2,11 +2,13 @@
 
 """Representations for nodes and relations to upload to Neo4j."""
 
-from typing import Any, Collection, Mapping, Optional
+from typing import Any, Collection, Mapping, Optional, Tuple
 
 __all__ = ["Node", "Relation"]
 
 from indra.databases import identifiers
+from indra.ontology.standardize import get_standard_name, standardize_db_refs
+from indra.statements.agent import get_grounding
 
 
 class Node:
@@ -116,6 +118,18 @@ class Relation:
 
     def __repr__(self):  # noqa:D105
         return str(self)
+
+
+def standardize(
+    prefix: str, identifier: str, name: Optional[str] = None
+) -> Tuple[str, str, str]:
+    """Get a standardized prefix, identifier, and name, if possible."""
+    db_refs = standardize_db_refs({prefix: identifier})
+    db_ns, db_id = get_grounding(db_refs)
+    if db_ns is None or db_id is None:
+        return prefix, identifier, name
+    name = get_standard_name(db_refs) or name
+    return db_ns, db_id, name
 
 
 def norm_id(db_ns, db_id):

--- a/src/indra_cogex/representation.py
+++ b/src/indra_cogex/representation.py
@@ -142,7 +142,7 @@ def standardize(
     prefix: str, identifier: str, name: Optional[str] = None
 ) -> Tuple[str, str, str]:
     """Get a standardized prefix, identifier, and name, if possible."""
-    db_refs, standard_name = standardize_name_db_refs({prefix: identifier})
+    standard_name, db_refs = standardize_name_db_refs({prefix: identifier})
     name = standard_name if standard_name else name
     db_ns, db_id = get_grounding(db_refs)
     if db_ns is None or db_id is None:

--- a/src/indra_cogex/sources/__init__.py
+++ b/src/indra_cogex/sources/__init__.py
@@ -5,17 +5,19 @@
 from class_resolver import Resolver
 
 from .bgee import BgeeProcessor
+from .cbioportal import (
+    CcleCnaProcessor,
+    CcleDrugResponseProcessor,
+    CcleMutationsProcessor,
+)
+from .chembl import ChemblIndicationsProcessor
+from .clinicaltrials import ClinicaltrialsProcessor
 from .goa import GoaProcessor
 from .indra_db import DbProcessor
 from .indra_ontology import OntologyProcessor
 from .pathways import ReactomeProcessor, WikipathwaysProcessor
-from .cbioportal import (
-    CcleCnaProcessor,
-    CcleMutationsProcessor,
-    CcleDrugResponseProcessor,
-)
-from .clinicaltrials import ClinicaltrialsProcessor
 from .processor import Processor
+from .sider import SIDERSideEffectProcessor
 
 __all__ = [
     "processor_resolver",
@@ -30,6 +32,8 @@ __all__ = [
     "CcleMutationsProcessor",
     "CcleDrugResponseProcessor",
     "ClinicaltrialsProcessor",
+    "ChemblIndicationsProcessor",
+    "SIDERSideEffectProcessor",
 ]
 
 processor_resolver = Resolver.from_subclasses(Processor)

--- a/src/indra_cogex/sources/chembl/__init__.py
+++ b/src/indra_cogex/sources/chembl/__init__.py
@@ -82,6 +82,6 @@ class ChemblIndicationsProcessor(Processor):
                 dict(
                     source=self.name,
                     max_phase=max_phase,
-                    versions=self.version,
+                    version=self.version,
                 ),
             )

--- a/src/indra_cogex/sources/chembl/__init__.py
+++ b/src/indra_cogex/sources/chembl/__init__.py
@@ -79,5 +79,9 @@ class ChemblIndicationsProcessor(Processor):
                 indication.db_ns,
                 indication.db_id,
                 "treats",
-                dict(source=self.name, versions=self.version),
+                dict(
+                    source=self.name,
+                    max_phase=max_phase,
+                    versions=self.version,
+                ),
             )

--- a/src/indra_cogex/sources/chembl/__init__.py
+++ b/src/indra_cogex/sources/chembl/__init__.py
@@ -78,7 +78,7 @@ class ChemblIndicationsProcessor(Processor):
                 chemical.db_id,
                 indication.db_ns,
                 indication.db_id,
-                "treats",
+                "has_indication",
                 dict(
                     source=self.name,
                     max_phase=max_phase,

--- a/src/indra_cogex/sources/chembl/__init__.py
+++ b/src/indra_cogex/sources/chembl/__init__.py
@@ -70,9 +70,7 @@ class ChemblIndicationsProcessor(Processor):
 
     def get_relations(self) -> Iterable[Relation]:
         """Iterate over ChEMBL indication annotations."""
-        for chembl_id, mesh_id, max_phase in tqdm(
-            self.df.values, unit_scale=True, desc="chembl indication relations"
-        ):
+        for chembl_id, mesh_id, max_phase in self.df.values:
             chemical = self.chemicals[chembl_id]
             indication = self.indications[mesh_id]
             yield Relation(

--- a/src/indra_cogex/sources/chembl/__init__.py
+++ b/src/indra_cogex/sources/chembl/__init__.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+
+"""Processor for ChEMBL."""
+
+import logging
+from typing import Iterable, Optional, Tuple
+
+import bioversions
+import chembl_downloader
+from tqdm import tqdm
+
+from indra.ontology.standardize import (
+    get_grounding,
+    get_standard_name,
+    standardize_db_refs,
+)
+from indra_cogex.representation import Node, Relation
+from indra_cogex.sources.processor import Processor
+
+logger = logging.getLogger(__name__)
+
+#: SQL for ChEMBL to get molecules that have indications
+MOLECULE_SQL = f"""
+SELECT DISTINCT
+    MOLECULE_DICTIONARY.chembl_id,
+    MOLECULE_DICTIONARY.pref_name
+FROM MOLECULE_DICTIONARY
+JOIN DRUG_INDICATION ON MOLECULE_DICTIONARY.molregno == DRUG_INDICATION.molregno
+"""
+
+#: SQL for ChEMBL to get indications
+SQL = f"""
+SELECT
+    MOLECULE_DICTIONARY.chembl_id,
+    DRUG_INDICATION.mesh_id,
+    DRUG_INDICATION.max_phase_for_ind
+FROM MOLECULE_DICTIONARY
+JOIN DRUG_INDICATION ON MOLECULE_DICTIONARY.molregno == DRUG_INDICATION.molregno
+"""
+
+
+class ChemblIndicationsProcessor(Processor):
+    """A processor for ChEMBL indications."""
+
+    name = "chembl"
+
+    def __init__(self, version: Optional[str] = None):
+        self.version = version or bioversions.get_version("chembl")
+        self.df = chembl_downloader.query(SQL, version=self.version)
+
+        self.chemicals = {}
+        chemical_df = chembl_downloader.query(MOLECULE_SQL, version=version)
+        for chembl_id, chembl_name in tqdm(
+            chemical_df.values, unit_scale=True, desc="caching chemicals"
+        ):
+            db_ns, db_id, name = self._standardize("CHEMBL", chembl_id, chembl_name)
+            self.chemicals[chembl_id] = Node(
+                db_ns,
+                db_id,
+                ["BioEntity"],
+                dict(name=name),
+            )
+
+        self.indications = {}
+        for mesh_id in tqdm(
+            self.df.mesh_id.unique(), unit_scale=True, desc="caching indications"
+        ):
+            db_ns, db_id, name = self._standardize("MESH", mesh_id)
+            if name is None:
+                tqdm.write(f"no name found for MESH:{mesh_id}")
+            self.indications[mesh_id] = Node(
+                db_ns,
+                db_id,
+                ["BioEntity"],
+                dict(name=name),
+            )
+
+    def _standardize(
+        self, prefix: str, identifier: str, name: Optional[str] = None
+    ) -> Tuple[str, str, str]:
+        db_refs = standardize_db_refs({prefix: identifier})
+        db_ns, db_id = get_grounding(db_refs)
+        if db_ns is None or db_id is None:
+            return prefix, identifier, name
+        name = get_standard_name(db_refs) or name
+        return db_ns, db_id, name
+
+    def get_nodes(self) -> Iterable[Node]:
+        """Iterate over ChEMBL chemicals and indications"""
+        yield from self.chemicals.values()
+        yield from self.indications.values()
+
+    def get_relations(self) -> Iterable[Relation]:
+        """Iterate over ChEMBL indication annotations."""
+        for chembl_id, mesh_id, max_phase in tqdm(
+            self.df.values, unit_scale=True, desc="chembl indication relations"
+        ):
+            chemical = self.chemicals[chembl_id]
+            indication = self.indications[mesh_id]
+            yield Relation(
+                chemical.db_ns,
+                chemical.db_id,
+                indication.db_ns,
+                indication.db_id,
+                "treats",
+                dict(source=self.name, versions=self.version),
+            )

--- a/src/indra_cogex/sources/chembl/__main__.py
+++ b/src/indra_cogex/sources/chembl/__main__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+"""Run the pathways processor using ``python -m indra_cogex.sources.chembl``."""
+
+from . import ChemblIndicationsProcessor
+
+if __name__ == "__main__":
+    ChemblIndicationsProcessor.cli()

--- a/src/indra_cogex/sources/sider/__init__.py
+++ b/src/indra_cogex/sources/sider/__init__.py
@@ -15,9 +15,11 @@ from biomappings import load_mappings
 from tabulate import tabulate
 from tqdm import tqdm
 
+from indra.databases import biolookup_client
 from indra.databases.identifiers import get_ns_id_from_identifiers
 from indra_cogex.representation import Node, Relation, standardize
 from indra_cogex.sources import Processor
+
 
 VERSION = "4.1"
 SUBMODULE = pystow.module("indra", "cogex", "sider", VERSION)
@@ -140,9 +142,12 @@ class SIDERSideEffectProcessor(Processor):
                 labels=["BioEntity"],
             )
             for pubchem_id in tqdm(
-                self.df["pubchem_id"], unit_scale=True, desc="caching chemicals"
+                self.df["pubchem_id"], unit_scale=True, desc="Caching chemicals"
             )
         }
+        for node in tqdm(self.chemicals.values(), desc="Finding chemical names"):
+            if node.data["name"] is None:
+                node.data["name"] = biolookup_client.get_name(node.db_ns, node.db_id)
 
         umls_mapper = UmlsMapper()
         self.side_effects = {}

--- a/src/indra_cogex/sources/sider/__init__.py
+++ b/src/indra_cogex/sources/sider/__init__.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+
+"""Processor for SIDER."""
+
+from collections import Counter
+from typing import Iterable
+
+import pandas as pd
+from biomappings import load_mappings
+from tabulate import tabulate
+from tqdm import tqdm
+
+import gilda
+import gilda.grounder
+import pyobo
+from indra.databases.identifiers import get_ns_id_from_identifiers
+from indra_cogex.constants import MODULE
+from indra_cogex.representation import Node, Relation, standardize
+from indra_cogex.sources import Processor
+
+VERSION = "4.1"
+SUBMODULE = MODULE.submodule("indra", "cogex", "sider", VERSION)
+URL = "http://sideeffects.embl.de/media/download/meddra_all_se.tsv.gz"
+SIDE_EFFECTS_HEADER = [
+    # 'STITCH_FLAT_ID',
+    "STITCH_STEREO_ID",
+    # 'UMLS CUI from Label',
+    "MedDRA Concept Type",
+    "UMLS CUI from MedDRA",
+    "MedDRA Concept name",
+]
+
+
+def stitch_stereo_to_pubchem(cid: str) -> str:
+    assert cid.startswith("CID")
+    return str(cid[3:])
+
+
+class UmlsMapper:
+    """A utility class for mapping out of UMLS."""
+
+    prefixes = ["doid", "mesh", "hp", "efo", "mondo"]
+
+    def __init__(self):
+        """Prepare the UMLS mappings from PyOBO and Biomappings."""
+        #: A dictionary from external prefix to UMLS id to external ID
+        self.xrefs = {}
+
+        for prefix in self.prefixes:
+            self.xrefs[prefix] = {}
+            # Get external to UMLS
+            for external_id, umls_id in pyobo.get_filtered_xrefs(
+                prefix, "umls"
+            ).items():
+                self.xrefs[prefix][umls_id] = external_id
+            # Get UMLS to external
+            for umls_id, external_id in pyobo.get_filtered_xrefs(
+                "umls", prefix
+            ).items():
+                self.xrefs[prefix][umls_id] = external_id
+
+        # Get manually curated UMLS mappings from biomappings
+        biomappings_from_umls, biomappings_to_umls = Counter(), Counter()
+        for mapping in load_mappings():
+            if mapping["source prefix"] == "umls":
+                target_prefix = mapping["target prefix"]
+                biomappings_from_umls[target_prefix] += 1
+                target_id = mapping["target identifier"]
+                source_id = mapping["source identifier"]
+                if target_prefix in self.xrefs:
+                    self.xrefs[target_prefix][target_id] = source_id
+                else:
+                    self.xrefs[target_prefix] = {
+                        target_id: source_id,
+                    }
+            elif mapping["target prefix"] == "umls":
+                source_prefix = mapping["source prefix"]
+                biomappings_to_umls[source_prefix] += 1
+                source_id = mapping["source identifier"]
+                target_id = mapping["target identifier"]
+                if source_prefix in self.xrefs:
+                    self.xrefs[source_prefix][source_id] = target_id
+                else:
+                    self.xrefs[source_prefix] = {
+                        source_id: target_id,
+                    }
+
+        print("Mapping out of UMLS")
+        print(tabulate(biomappings_from_umls.most_common()))
+        print("Mapping into UMLS")
+        print(tabulate(biomappings_to_umls.most_common()))
+
+        print("Total xrefs")
+        print(
+            tabulate(
+                [(prefix, len(self.xrefs[prefix])) for prefix in self.prefixes],
+                headers=["Prefix", "Mappings"],
+            )
+        )
+
+    def lookup(self, umls_id: str):
+        for prefix in self.prefixes:
+            xrefs = self.xrefs[prefix]
+            identifier = xrefs.get(umls_id)
+            if identifier is not None:
+                return standardize(prefix, identifier)
+        return "umls", umls_id, pyobo.get_name("umls", umls_id)
+
+
+class SIDERSideEffectProcessor(Processor):
+    """A processor for SIDER side effects."""
+
+    name = "sider_side_effects"
+
+    def __init__(self):
+        self.df = SUBMODULE.ensure_csv(
+            url=URL,
+            read_csv_kwargs=dict(
+                usecols=[1, 3, 4, 5],
+                names=SIDE_EFFECTS_HEADER,
+                dtype=str,
+            ),
+        )
+        self.df = self.df[self.df["STITCH_STEREO_ID"].notna()]
+        self.df = self.df[self.df["UMLS CUI from MedDRA"].notna()]
+
+        # Prepare chemicals
+        self.df["pubchem_id"] = self.df["STITCH_STEREO_ID"].map(
+            stitch_stereo_to_pubchem
+        )
+        del self.df["STITCH_STEREO_ID"]
+        self.chemicals = {
+            pubchem_id: Node.standardized(
+                db_ns="PUBCHEM",
+                db_id=pubchem_id,
+                labels=["BioEntity"],
+            )
+            for pubchem_id in tqdm(
+                self.df["pubchem_id"], unit_scale=True, desc="caching chemicals"
+            )
+        }
+
+        umls_mapper = UmlsMapper()
+        self.side_effects = {}
+        for umls_id in self.df["UMLS CUI from MedDRA"].unique():
+            prefix, identifier, name = umls_mapper.lookup(umls_id)
+            db_ns, db_id = get_ns_id_from_identifiers(prefix, identifier)
+            if db_ns is None:
+                db_ns, db_id = prefix, identifier
+            self.side_effects[umls_id] = Node.standardized(
+                db_ns=db_ns, db_id=db_id, name=name, labels=["BioEntity"]
+            )
+
+    def get_nodes(self) -> Iterable[Node]:
+        """Iterate over SIDER chemicals and side effects."""
+        yield from self.chemicals.values()
+        yield from self.side_effects.values()
+
+    def get_relations(self) -> Iterable[Relation]:
+        """Iterate over SIDER side effect annotations."""
+        for pubchem_id, umls_id in self.df[
+            ["pubchem_id", "UMLS CUI from MedDRA"]
+        ].values:
+            chemical = self.chemicals[pubchem_id]
+            indication = self.side_effects[umls_id]
+            yield Relation(
+                chemical.db_ns,
+                chemical.db_id,
+                indication.db_ns,
+                indication.db_id,
+                "causes",
+                dict(
+                    source=self.name,
+                    version=VERSION,
+                ),
+            )
+
+
+def generate_curation_sheet():
+    """This function does some statistics over the UMLS mappings out of SIDER and generates
+    a curation sheet based on gilda when possible. Still, about half of the terms are only
+    available in UMLS at the moment.
+    """
+    umls_mapper = UmlsMapper()
+
+    df = SUBMODULE.ensure_csv(
+        url=URL,
+        read_csv_kwargs=dict(
+            usecols=[1, 3, 4, 5],
+            names=SIDE_EFFECTS_HEADER,
+            dtype=str,
+        ),
+    )
+    df["pubchem_id"] = df["STITCH_STEREO_ID"].map(stitch_stereo_to_pubchem)
+    del df["STITCH_STEREO_ID"]
+
+    print(tabulate(df.head(), headers=df.columns))
+    umls_ids = df["UMLS CUI from MedDRA"].unique()
+    unique_umls_id_count = len(umls_ids)
+    print("Unique UMLS identifiers:", unique_umls_id_count)
+    c = Counter()
+    unnormalized = set()
+    for umls_id in tqdm(umls_ids):
+        db_ns, db_id, name = umls_mapper.lookup(umls_id)
+        if db_ns is not None:
+            c[db_ns] += 1
+        else:
+            unnormalized.add(umls_id)
+
+    print("Most common prefixes mapped from UMLS to")
+    print(tabulate(c.most_common()))
+
+    number_normalized = sum(c.values())
+    print(
+        f"normalized  : {number_normalized}/{unique_umls_id_count} ({number_normalized / unique_umls_id_count:.2%})"
+    )
+    print(
+        f"unnormalized: {len(unnormalized)}/{unique_umls_id_count} ({len(unnormalized) / unique_umls_id_count:.2%})"
+    )
+
+    print("mapping all rows")
+    df["prefix"], df["identifier"], df["name"] = zip(
+        *df["UMLS CUI from MedDRA"].map(umls_mapper.lookup)
+    )
+    df.to_csv(SUBMODULE.join(name="norm_df.tsv"), sep="\t", index=False)
+
+    df_unnormalized = df.loc[df["prefix"].isna()]
+    unique_unnormalized = {
+        (umls_id, name)
+        for umls_id, name in df_unnormalized[
+            ["UMLS CUI from MedDRA", "MedDRA Concept name"]
+        ].values
+        if pd.notna(name) and pd.notna(umls_id)
+    }
+    rows = []
+    for umls_id, name in sorted(unique_unnormalized):
+        for result in gilda.ground(name):
+            result: gilda.grounder.ScoredMatch
+            term: gilda.grounder.Term = result.term
+            rows.append(
+                (
+                    umls_id,
+                    name,
+                    term.db,
+                    term.id,
+                    term.entry_name,
+                    result.score,
+                )
+            )
+    curation_df = pd.DataFrame(
+        rows, columns=["umls_id", "umls_name", "prefix", "identifier", "name", "score"]
+    )
+    curation_df.to_csv(SUBMODULE.join(name="curation_df.tsv"), sep="\t", index=False)
+
+
+if __name__ == "__main__":
+    SIDERSideEffectProcessor.cli()

--- a/src/indra_cogex/sources/sider/__init__.py
+++ b/src/indra_cogex/sources/sider/__init__.py
@@ -5,21 +5,21 @@
 from collections import Counter
 from typing import Iterable
 
+import gilda
+import gilda.grounder
 import pandas as pd
+import pyobo
+import pystow
 from biomappings import load_mappings
 from tabulate import tabulate
 from tqdm import tqdm
 
-import gilda
-import gilda.grounder
-import pyobo
 from indra.databases.identifiers import get_ns_id_from_identifiers
-from indra_cogex.constants import MODULE
 from indra_cogex.representation import Node, Relation, standardize
 from indra_cogex.sources import Processor
 
 VERSION = "4.1"
-SUBMODULE = MODULE.submodule("indra", "cogex", "sider", VERSION)
+SUBMODULE = pystow.module("indra", "cogex", "sider", VERSION)
 URL = "http://sideeffects.embl.de/media/download/meddra_all_se.tsv.gz"
 SIDE_EFFECTS_HEADER = [
     # 'STITCH_FLAT_ID',

--- a/src/indra_cogex/sources/sider/__init__.py
+++ b/src/indra_cogex/sources/sider/__init__.py
@@ -2,6 +2,7 @@
 
 """Processor for SIDER."""
 
+import re
 from collections import Counter
 from typing import Iterable
 
@@ -31,9 +32,12 @@ SIDE_EFFECTS_HEADER = [
 ]
 
 
+cid_to_pubchem_pattern = re.compile(r"^CID(?:0)+(\d+)$")
+
+
 def stitch_stereo_to_pubchem(cid: str) -> str:
     assert cid.startswith("CID")
-    return str(cid[3:])
+    return re.sub(cid_to_pubchem_pattern, "\\1", cid)
 
 
 class UmlsMapper:
@@ -168,7 +172,7 @@ class SIDERSideEffectProcessor(Processor):
                 chemical.db_id,
                 indication.db_ns,
                 indication.db_id,
-                "causes",
+                "has_side_effect",
                 dict(
                     source=self.name,
                     version=VERSION,

--- a/src/indra_cogex/sources/sider/__main__.py
+++ b/src/indra_cogex/sources/sider/__main__.py
@@ -1,0 +1,4 @@
+from . import SIDERSideEffectProcessor
+
+if __name__ == "__main__":
+    SIDERSideEffectProcessor.cli()


### PR DESCRIPTION
Closes #39

This PR adds a processor over the ChEMBL database based on SQL queries executed by the [`chembl_downloader`](https://github.com/cthoyt/chembl_downloader). It standardizes the ChEMBL identifiers for chemicals and the MeSH identifiers for indications using the INDRA BioOntology. The code that does this is probably generally reusable so I gave it a its own utility function.

This PR also adds the processor for SIDER side effects since it shares some of the standardization code from the ChEMBL processor