### PR TITLE
INDRA Statement processor update

### DIFF
--- a/src/indra_cogex/neo4j_client.py
+++ b/src/indra_cogex/neo4j_client.py
@@ -171,13 +171,7 @@ class Neo4jClient:
             "{id: '%s'}" % target if target else "t",
             "" if not limit else "LIMIT %s" % limit,
         )
-        rels = []
-        for res in self.query_tx(query):
-            try:
-                rels.append(self.neo4j_to_relation(res[0]))
-            except Exception as e:
-                logger.warning(e)
-                logger.warning(res[0])
+        rels = [self.neo4j_to_relation(res[0]) for res in self.query_tx(query)]
         return rels
 
     def get_source_relations(


### PR DESCRIPTION
This PR extends the DB Processor to optionally add the statement JSONs into Relation data. To enable this, set `add_jsons=True` when instantiating the DbProcessor class or add `add_jsons` flag in the command (e.g. `python -m indra_db --add_jsons`).
#TODO Parameterize this when building the full graph from all sources. 