### PR TITLE
Add evidence subgraph and refactor import CLI

### DIFF
--- a/import.sh
+++ b/import.sh
@@ -36,6 +36,6 @@ $NEO4J_PREFIX rm -rf $NEO4J_DATA/transactions/indra
 cat $NEO4J_CONFIG/neo4j.conf | grep "dbms\.default_database"
 
 
-python -m indra_cogex.sources --load $COGEX_SUDO_ARG
+python -m indra_cogex.sources --process --assemble --run_import $COGEX_SUDO_ARG
 
 $NEO4J_PREFIX neo4j start

--- a/src/indra_cogex/sources/__init__.py
+++ b/src/indra_cogex/sources/__init__.py
@@ -13,10 +13,11 @@ from .cbioportal import (
 from .chembl import ChemblIndicationsProcessor
 from .clinicaltrials import ClinicaltrialsProcessor
 from .goa import GoaProcessor
-from .indra_db import DbProcessor
+from .indra_db import DbProcessor, EvidenceProcessor
 from .indra_ontology import OntologyProcessor
 from .pathways import ReactomeProcessor, WikipathwaysProcessor
 from .processor import Processor
+from .pubmed import PubmedProcessor
 from .sider import SIDERSideEffectProcessor
 
 __all__ = [
@@ -34,6 +35,8 @@ __all__ = [
     "ClinicaltrialsProcessor",
     "ChemblIndicationsProcessor",
     "SIDERSideEffectProcessor",
+    "EvidenceProcessor",
+    "PubmedProcessor"
 ]
 
 processor_resolver = Resolver.from_subclasses(Processor)

--- a/src/indra_cogex/sources/bgee/__init__.py
+++ b/src/indra_cogex/sources/bgee/__init__.py
@@ -32,7 +32,7 @@ class BgeeProcessor(Processor):
         with open(path, "rb") as fh:
             self.expressions = pickle.load(fh)
 
-    def get_nodes(self, **kwargs):  # noqa:D102
+    def get_nodes(self):  # noqa:D102
         for context in self.expressions:
             context_ns, context_id = get_context(context)
             yield Node(

--- a/src/indra_cogex/sources/bgee/__init__.py
+++ b/src/indra_cogex/sources/bgee/__init__.py
@@ -17,6 +17,7 @@ class BgeeProcessor(Processor):
     """Processor for Bgee."""
 
     name = "bgee"
+    node_type = "BioEntity"
 
     def __init__(self, path: Union[None, str, Path] = None):
         """Initialize the Bgee processor.

--- a/src/indra_cogex/sources/bgee/__init__.py
+++ b/src/indra_cogex/sources/bgee/__init__.py
@@ -17,7 +17,7 @@ class BgeeProcessor(Processor):
     """Processor for Bgee."""
 
     name = "bgee"
-    node_type = "BioEntity"
+    node_types = ["BioEntity"]
 
     def __init__(self, path: Union[None, str, Path] = None):
         """Initialize the Bgee processor.

--- a/src/indra_cogex/sources/bgee/__init__.py
+++ b/src/indra_cogex/sources/bgee/__init__.py
@@ -32,7 +32,7 @@ class BgeeProcessor(Processor):
         with open(path, "rb") as fh:
             self.expressions = pickle.load(fh)
 
-    def get_nodes(self):  # noqa:D102
+    def get_nodes(self, **kwargs):  # noqa:D102
         for context in self.expressions:
             context_ns, context_id = get_context(context)
             yield Node(

--- a/src/indra_cogex/sources/cbioportal/__init__.py
+++ b/src/indra_cogex/sources/cbioportal/__init__.py
@@ -39,7 +39,7 @@ class CcleMutationsProcessor(Processor):
 
         self.df = pd.read_csv(path, sep="\t", comment="#")
 
-    def get_nodes(self, **kwargs):
+    def get_nodes(self):
         for hgnc_symbol in sorted(set(self.df["Hugo_Symbol"])):
             hgnc_id = hgnc_client.get_hgnc_id(hgnc_symbol)
             if not hgnc_id:
@@ -85,7 +85,7 @@ class CcleCnaProcessor(Processor):
 
         self.df = pd.read_csv(path, sep="\t")
 
-    def get_nodes(self, **kwargs):
+    def get_nodes(self):
         # Collect all gene symbols from both tables
         for hgnc_symbol in sorted(set(self.df["Hugo_Symbol"])):
             hgnc_id = hgnc_client.get_hgnc_id(hgnc_symbol)
@@ -135,7 +135,7 @@ class CcleDrugResponseProcessor(Processor):
         self.df = pd.read_csv(path, sep="\t")
         self.drug_mappings = {}
 
-    def get_nodes(self, **kwargs):
+    def get_nodes(self):
         drugs = self.get_drug_mappings()
         for db_ns, db_id in drugs.values():
             if db_ns and db_id:

--- a/src/indra_cogex/sources/cbioportal/__init__.py
+++ b/src/indra_cogex/sources/cbioportal/__init__.py
@@ -39,7 +39,7 @@ class CcleMutationsProcessor(Processor):
 
         self.df = pd.read_csv(path, sep="\t", comment="#")
 
-    def get_nodes(self):
+    def get_nodes(self, **kwargs):
         for hgnc_symbol in sorted(set(self.df["Hugo_Symbol"])):
             hgnc_id = hgnc_client.get_hgnc_id(hgnc_symbol)
             if not hgnc_id:
@@ -85,7 +85,7 @@ class CcleCnaProcessor(Processor):
 
         self.df = pd.read_csv(path, sep="\t")
 
-    def get_nodes(self):
+    def get_nodes(self, **kwargs):
         # Collect all gene symbols from both tables
         for hgnc_symbol in sorted(set(self.df["Hugo_Symbol"])):
             hgnc_id = hgnc_client.get_hgnc_id(hgnc_symbol)
@@ -135,7 +135,7 @@ class CcleDrugResponseProcessor(Processor):
         self.df = pd.read_csv(path, sep="\t")
         self.drug_mappings = {}
 
-    def get_nodes(self):
+    def get_nodes(self, **kwargs):
         drugs = self.get_drug_mappings()
         for db_ns, db_id in drugs.values():
             if db_ns and db_id:

--- a/src/indra_cogex/sources/cbioportal/__init__.py
+++ b/src/indra_cogex/sources/cbioportal/__init__.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 class CcleMutationsProcessor(Processor):
     name = "ccle_mutations"
-    node_type = "BioEntity"
+    node_types = ["BioEntity"]
 
     def __init__(
         self,
@@ -68,7 +68,7 @@ class CcleMutationsProcessor(Processor):
 
 class CcleCnaProcessor(Processor):
     name = "ccle_cna"
-    node_type = "BioEntity"
+    node_types = ["BioEntity"]
 
     def __init__(
         self,
@@ -115,7 +115,7 @@ class CcleCnaProcessor(Processor):
 
 class CcleDrugResponseProcessor(Processor):
     name = "ccle_drug"
-    node_type = "BioEntity"
+    node_types = ["BioEntity"]
 
     def __init__(self, path: Union[str, Path, None] = None):
 

--- a/src/indra_cogex/sources/cbioportal/__init__.py
+++ b/src/indra_cogex/sources/cbioportal/__init__.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 class CcleMutationsProcessor(Processor):
     name = "ccle_mutations"
+    node_type = "BioEntity"
 
     def __init__(
         self,
@@ -67,6 +68,7 @@ class CcleMutationsProcessor(Processor):
 
 class CcleCnaProcessor(Processor):
     name = "ccle_cna"
+    node_type = "BioEntity"
 
     def __init__(
         self,
@@ -113,6 +115,7 @@ class CcleCnaProcessor(Processor):
 
 class CcleDrugResponseProcessor(Processor):
     name = "ccle_drug"
+    node_type = "BioEntity"
 
     def __init__(self, path: Union[str, Path, None] = None):
 

--- a/src/indra_cogex/sources/chembl/__init__.py
+++ b/src/indra_cogex/sources/chembl/__init__.py
@@ -38,7 +38,7 @@ class ChemblIndicationsProcessor(Processor):
     """A processor for ChEMBL indications."""
 
     name = "chembl"
-    node_type = "BioEntity"
+    node_types = ["BioEntity"]
 
     def __init__(self, version: Optional[str] = None):
         self.version = version or bioversions.get_version("chembl")

--- a/src/indra_cogex/sources/chembl/__init__.py
+++ b/src/indra_cogex/sources/chembl/__init__.py
@@ -64,7 +64,7 @@ class ChemblIndicationsProcessor(Processor):
             )
         }
 
-    def get_nodes(self, **kwargs) -> Iterable[Node]:
+    def get_nodes(self) -> Iterable[Node]:
         """Iterate over ChEMBL chemicals and indications"""
         yield from self.chemicals.values()
         yield from self.indications.values()

--- a/src/indra_cogex/sources/chembl/__init__.py
+++ b/src/indra_cogex/sources/chembl/__init__.py
@@ -64,7 +64,7 @@ class ChemblIndicationsProcessor(Processor):
             )
         }
 
-    def get_nodes(self) -> Iterable[Node]:
+    def get_nodes(self, **kwargs) -> Iterable[Node]:
         """Iterate over ChEMBL chemicals and indications"""
         yield from self.chemicals.values()
         yield from self.indications.values()

--- a/src/indra_cogex/sources/chembl/__init__.py
+++ b/src/indra_cogex/sources/chembl/__init__.py
@@ -38,6 +38,7 @@ class ChemblIndicationsProcessor(Processor):
     """A processor for ChEMBL indications."""
 
     name = "chembl"
+    node_type = "BioEntity"
 
     def __init__(self, version: Optional[str] = None):
         self.version = version or bioversions.get_version("chembl")

--- a/src/indra_cogex/sources/cli.py
+++ b/src/indra_cogex/sources/cli.py
@@ -118,7 +118,7 @@ def main(
             processed = False
         edge_paths.append(processor_cls.edges_path)
         click.secho(
-            f"Identified node paths for assembly: {[str(p) for p in processor_to_assemble_paths]}",
+            f"Identified node paths for assembly: {[str(p) for p in processor_to_assemble_paths.values()]}",
             fg="blue",
         )
         click.secho(

--- a/src/indra_cogex/sources/cli.py
+++ b/src/indra_cogex/sources/cli.py
@@ -138,7 +138,7 @@ def main(
             click.secho("Processing...", fg="green")
             # First dump the nodes and edges for processor
             _, nodes_by_type, _ = processor.dump()
-            # Add nodes to assembly or store as preprocessed depending on node type
+            # Add nodes to assembly if needed
             for node_type, nodes in nodes_by_type.items():
                 if node_type in to_assemble:
                     assembled_path = _get_assembled_path(node_type)
@@ -147,14 +147,18 @@ def main(
                         if node_type not in node_assemblers:
                             node_assemblers[node_type] = NodeAssembler()
                         node_assemblers[node_type].add_nodes(nodes)
-        elif processed:
-            # If we don't need to assemble, we'll just skip to importing
+        elif processed:  # force_process=False, process=True/False
+            # If we don't need to assemble, we'll just skip this
             for node_type, nodes_indra_path in processor_to_assemble_paths.items():
                 assembled_path = _get_assembled_path(node_type)
                 if force_assemble or (assemble and not assembled_path.exists()):
                     # Instantiate the assembler or add nodes to existing assembler
                     if node_type not in node_assemblers:
                         node_assemblers[node_type] = NodeAssembler()
+                        click.secho(
+                            f"Loading cached nodes from {nodes_indra_path}",
+                            fg="green",
+                        )
                     with open(nodes_indra_path, "rb") as fh:
                         nodes = pickle.load(fh)
                     node_assemblers[node_type].add_nodes(nodes)

--- a/src/indra_cogex/sources/cli.py
+++ b/src/indra_cogex/sources/cli.py
@@ -31,25 +31,21 @@ def _get_assembled_path(node_type: str) -> Path:
 
 @click.command()
 @click.option(
-    "-f",
     "--process",
     is_flag=True,
     help="If true, builds all missing resouces.",
 )
 @click.option(
-    "-f",
     "--force_process",
     is_flag=True,
     help="If true, rebuilds all resources",
 )
 @click.option(
-    "-f",
     "--assemble",
     is_flag=True,
     help="If true, assembles all (not yet assembled) nodes.",
 )
 @click.option(
-    "-f",
     "--force_assemble",
     is_flag=True,
     help="If true, reassembles all nodes.",

--- a/src/indra_cogex/sources/cli.py
+++ b/src/indra_cogex/sources/cli.py
@@ -121,7 +121,14 @@ def main(
         if not processor_cls.edges_path.exists():
             processed = False
         edge_paths.append(processor_cls.edges_path)
-
+        click.secho(
+            f"Identified node paths for assembly: {processor_to_assemble_paths}",
+            fg="blue",
+        )
+        click.secho(
+            f"Identified node paths for import: {processor_import_paths}",
+            fg="blue",
+        )
         # Run the processor if needed
         if force_process or (process and not processed):
             try:

--- a/src/indra_cogex/sources/cli.py
+++ b/src/indra_cogex/sources/cli.py
@@ -69,7 +69,7 @@ def _get_assembled_path(node_type: str) -> Path:
 @click.option(
     "--skip_failed_processors",
     is_flag=True,
-    help="If true, doesn't explode on missing files",
+    help="If true, skips processors that are missing required input files without erroring.",
 )
 @verbose_option
 def main(
@@ -130,7 +130,10 @@ def main(
             except FileNotFoundError as e:
                 if not skip_failed_processors:
                     raise
-                click.secho(f"Failed: {e}", fg="red")
+                click.secho(
+                    f"Failed: {e}, skipping corresponding nodes and relations from further processing and import",
+                    fg="red",
+                )
                 # Remove this processor's paths from the list of nodes/edges to import
                 for path in processor_import_paths:
                     nodes_paths_for_import.remove(path)
@@ -156,10 +159,10 @@ def main(
                     # Instantiate the assembler or add nodes to existing assembler
                     if node_type not in node_assemblers:
                         node_assemblers[node_type] = NodeAssembler()
-                        click.secho(
-                            f"Loading cached nodes from {nodes_indra_path}",
-                            fg="green",
-                        )
+                    click.secho(
+                        f"Loading cached nodes from {nodes_indra_path}",
+                        fg="green",
+                    )
                     with open(nodes_indra_path, "rb") as fh:
                         nodes = pickle.load(fh)
                     node_assemblers[node_type].add_nodes(nodes)

--- a/src/indra_cogex/sources/cli.py
+++ b/src/indra_cogex/sources/cli.py
@@ -110,7 +110,9 @@ def main(
                 # These will be imported directly
                 nodes_paths_for_import.append(proc_nodes_path)
                 processor_import_paths.append(proc_nodes_path)
-            if not proc_nodes_path.exists() or not nodes_indra_path.exists():
+            if not proc_nodes_path.exists() or (
+                nodes_indra_path and not nodes_indra_path.exists()
+            ):
                 processed = False
         if not processor_cls.edges_path.exists():
             processed = False

--- a/src/indra_cogex/sources/cli.py
+++ b/src/indra_cogex/sources/cli.py
@@ -176,7 +176,12 @@ def main(
         assembled_nodes = assembler.assemble_nodes()
         assembled_nodes = sorted(assembled_nodes, key=lambda x: (x.db_ns, x.db_id))
         Processor._dump_nodes_to_path(assembled_nodes, assembled_path)
-        nodes_paths_for_import.append(assembled_path)
+
+    # The assembled paths are added to the list of nodes to import separately
+    for node_type in to_assemble:
+        assembled_path = _get_assembled_path(node_type)
+        if assembled_path.exists():
+            nodes_paths_for_import.append(assembled_path)
 
     # Import the nodes
     if run_import:

--- a/src/indra_cogex/sources/cli.py
+++ b/src/indra_cogex/sources/cli.py
@@ -69,7 +69,9 @@ def main(
 ):
     """Generate and import Neo4j nodes and edges tables."""
     nodes_path = Path(nodes_path)
-    preprocessed_nodes_paths = []
+    # Paths to files with preprocessed nodes (e.g. BioEntities assembled with
+    # NodeAssembler or other types of nodes that do not need to be assembled)
+    preprocessed_nodes_paths = [nodes_path]
     config = {} if config is None else json.load(config)
     paths = []
     na = NodeAssembler()
@@ -133,12 +135,13 @@ def main(
           --database=indra \\
           --delimiter='TAB' \\
           --skip-duplicate-nodes=true \\
-          --skip-bad-relationships=true \\
-          --nodes {nodes_path}
+          --skip-bad-relationships=true
         """
         ).rstrip()
+        for node_path in preprocessed_nodes_paths:
+            command += f"\\\n --nodes {node_path}"
         for _, edge_path in paths:
-            command += f"\\\n  --relationships {edge_path}"
+            command += f"\\\n --relationships {edge_path}"
 
         click.secho("Running shell command:")
         click.secho(command, fg="blue")

--- a/src/indra_cogex/sources/cli.py
+++ b/src/indra_cogex/sources/cli.py
@@ -118,11 +118,11 @@ def main(
             processed = False
         edge_paths.append(processor_cls.edges_path)
         click.secho(
-            f"Identified node paths for assembly: {processor_to_assemble_paths}",
+            f"Identified node paths for assembly: {[str(p) for p in processor_to_assemble_paths]}",
             fg="blue",
         )
         click.secho(
-            f"Identified node paths for import: {processor_import_paths}",
+            f"Identified node paths for import: {[str(p) for p in processor_import_paths]}",
             fg="blue",
         )
         # Run the processor if needed

--- a/src/indra_cogex/sources/cli.py
+++ b/src/indra_cogex/sources/cli.py
@@ -22,22 +22,42 @@ def _iter_resolvers() -> Iterable[Type[Processor]]:
     return iter(processor_resolver)
 
 
+def _get_assembled_path(node_type: str) -> Path:
+    nodes_path = pystow.join(
+        "indra", "cogex", "assembled", name=f"nodes_{node_type}.tsv.gz"
+    )
+    return Path(nodes_path)
+
+
 @click.command()
 @click.option(
-    "--load",
+    "-f",
+    "--process",
     is_flag=True,
-    help="If true, automatically loads the data through ``neo4j-admin import``",
-)
-@click.option(
-    "--load_only",
-    is_flag=True,
-    help="If true, load the dumped data tables into neo4j without invoking sources",
+    help="If true, builds all missing resouces.",
 )
 @click.option(
     "-f",
-    "--force",
+    "--force_process",
     is_flag=True,
-    help="If true, rebuild all resources",
+    help="If true, rebuilds all resources",
+)
+@click.option(
+    "-f",
+    "--assemble",
+    is_flag=True,
+    help="If true, assembles all (not yet assembled) nodes.",
+)
+@click.option(
+    "-f",
+    "--force_assemble",
+    is_flag=True,
+    help="If true, reassembles all nodes.",
+)
+@click.option(
+    "--run_import",
+    is_flag=True,
+    help="If true, automatically loads the data through ``neo4j-admin import``",
 )
 @click.option(
     "--with_sudo",
@@ -51,94 +71,104 @@ def _iter_resolvers() -> Iterable[Type[Processor]]:
     " and values are dictionaries matching the __init__ parameters for the processor",
 )
 @click.option(
-    "--allow-missing", is_flag=True, help="If true, doesn't explode on missing files"
+    "--skip_failed_processors",
+    is_flag=True,
+    help="If true, doesn't explode on missing files",
 )
 @verbose_option
 def main(
-    load: bool,
-    load_only: bool,
-    force: bool,
+    process: bool,
+    force_process: bool,
+    assemble: bool,
+    force_assemble: bool,
+    run_import: bool,
     with_sudo: bool,
     config: Optional[TextIO],
-    allow_missing: bool,
+    skip_failed_processors: bool,
 ):
     """Generate and import Neo4j nodes and edges tables."""
-    # Paths to files with preprocessed nodes (e.g. assembled nodes or nodes that don't need to be assembled)
-    preprocessed_nodes_paths = []
     to_assemble = ["BioEntity", "Publication"]
+    # Paths to files with preprocessed nodes (e.g. assembled nodes or nodes that don't need to be assembled)
+    nodes_paths_for_import = [
+        _get_assembled_path(node_type) for node_type in to_assemble
+    ]
     config = {} if config is None else json.load(config)
-    paths = []
+    edge_paths = []
     node_assemblers = {}
     for processor_cls in _iter_resolvers():
         if not processor_cls.importable:
             continue
         click.secho(f"Checking {processor_cls.name}", fg="green", bold=True)
-        if not load_only:
-            if (
-                force
-                or not processor_cls.nodes_path.is_file()
-                or not processor_cls.nodes_indra_path.is_file()
-                or not processor_cls.edges_path.is_file()
-            ):
-                try:
-                    processor = processor_cls(**config.get(processor_cls.name, {}))
-                except FileNotFoundError as e:
-                    if not allow_missing:
-                        raise
-                    click.secho(f"Failed: {e}", fg="red")
-                    continue
-                click.secho("Processing...", fg="green")
-                # First dump the nodes and edges for processor
-                paths_by_type, nodes_by_type, _ = processor.dump()
-                # Assemble or store the paths to nodes depending on node type
-                for node_type, nodes in nodes_by_type.items():
-                    if node_type in to_assemble:
+        # First, get all required paths, we'll need them in the next steps
+        processed = True
+        processor_import_paths = []
+        processor_to_assemble_paths = {}
+        for node_type in processor_cls.node_types:
+            (
+                proc_nodes_path,
+                nodes_indra_path,
+                _,
+            ) = processor_cls._get_node_paths(node_type)
+            if node_type in to_assemble:
+                # Store the INDRA nodes pickle path for assembly
+                processor_to_assemble_paths[node_type] = nodes_indra_path
+            else:
+                # These will be imported directly
+                nodes_paths_for_import.append(proc_nodes_path)
+                processor_import_paths.append(proc_nodes_path)
+            if not proc_nodes_path.exists() or not nodes_indra_path.exists():
+                processed = False
+        if not processor_cls.edges_path.exists():
+            processed = False
+        edge_paths.append(processor_cls.edges_path)
+
+        # Run the processor if needed
+        if force_process or (process and not processed):
+            try:
+                processor = processor_cls(**config.get(processor_cls.name, {}))
+            except FileNotFoundError as e:
+                if not skip_failed_processors:
+                    raise
+                click.secho(f"Failed: {e}", fg="red")
+                # Remove this processor's paths from the list of nodes/edges to import
+                for path in processor_import_paths:
+                    nodes_paths_for_import.remove(path)
+                edge_paths.pop()
+                continue
+            click.secho("Processing...", fg="green")
+            # First dump the nodes and edges for processor
+            _, nodes_by_type, _ = processor.dump()
+            # Add nodes to assembly or store as preprocessed depending on node type
+            for node_type, nodes in nodes_by_type.items():
+                if node_type in to_assemble:
+                    assembled_path = _get_assembled_path(node_type)
+                    if force_assemble or (assemble and not assembled_path.exists()):
+                        # Instantiate the assembler or add nodes to existing assembler
                         if node_type not in node_assemblers:
                             node_assemblers[node_type] = NodeAssembler()
                         node_assemblers[node_type].add_nodes(nodes)
-                    else:
-                        preprocessed_nodes_paths.append(paths_by_type[node_type])
-            else:
-                # Get paths to the nodes by type
-                for node_type in processor_cls.nodes_types:
-                    (
-                        proc_nodes_path,
-                        nodes_indra_path,
-                        _,
-                    ) = processor_cls._get_node_paths(node_type)
-                    # Assemble or store the paths to nodes depending on node type
-                    if node_type in to_assemble:
-                        click.secho(
-                            f"Loading cached nodes from {nodes_indra_path}",
-                            fg="green",
-                        )
-                        with open(nodes_indra_path, "rb") as fh:
-                            nodes = pickle.load(fh)
-                            if node_type not in node_assemblers:
-                                node_assemblers[node_type] = NodeAssembler()
-                            node_assemblers[node_type].add_nodes(nodes)
-                    else:
-                        preprocessed_nodes_paths.append(proc_nodes_path)
+        elif processed:
+            # If we don't need to assemble, we'll just skip to importing
+            for node_type, nodes_indra_path in processor_to_assemble_paths.items():
+                assembled_path = _get_assembled_path(node_type)
+                if force_assemble or (assemble and not assembled_path.exists()):
+                    # Instantiate the assembler or add nodes to existing assembler
+                    if node_type not in node_assemblers:
+                        node_assemblers[node_type] = NodeAssembler()
+                    with open(nodes_indra_path, "rb") as fh:
+                        nodes = pickle.load(fh)
+                    node_assemblers[node_type].add_nodes(nodes)
 
-        paths.append((processor_cls.nodes_path, processor_cls.edges_path))
+    # Assemble nodes if we got any node assemblers above
+    if node_assemblers:
+        for node_type, assembler in node_assemblers.items():
+            assembled_path = _get_assembled_path(node_type)
+            click.secho(f"Assembling {node_type}", fg="green")
+            # This path is already in the list of nodes to import
+            assembler.assemble(assembled_path)
 
-    if not load_only:
-        # if force or not nodes_path.is_file():  # Removing this since there are multiple nodes files
-        if force:
-            # Now create and dump the assembled nodes for each node type
-            for node_type, na in node_assemblers.items():
-                nodes_path = pystow.join(
-                    "indra", "cogex", "assembled", name=f"nodes_{node_type}.tsv.gz"
-                )
-                nodes_path = Path(nodes_path)
-                assembled_nodes = na.assemble_nodes()
-                assembled_nodes = sorted(
-                    assembled_nodes, key=lambda x: (x.db_ns, x.db_id)
-                )
-                Processor._dump_nodes_to_path(assembled_nodes, nodes_path)
-                preprocessed_nodes_paths.append(nodes_path)
-
-    if load or load_only:
+    # Import the nodes
+    if run_import:
         sudo_prefix = "" if not with_sudo else "sudo"
         command = dedent(
             f"""\
@@ -149,9 +179,9 @@ def main(
           --skip-bad-relationships=true
         """
         ).rstrip()
-        for node_path in preprocessed_nodes_paths:
+        for node_path in nodes_paths_for_import:
             command += f"\\\n --nodes {node_path}"
-        for _, edge_path in paths:
+        for edge_path in edge_paths:
             command += f"\\\n --relationships {edge_path}"
 
         click.secho("Running shell command:")

--- a/src/indra_cogex/sources/clinicaltrials/__init__.py
+++ b/src/indra_cogex/sources/clinicaltrials/__init__.py
@@ -10,6 +10,7 @@ from indra_cogex.representation import Node, Relation
 
 class ClinicaltrialsProcessor(Processor):
     name = "clinicaltrials"
+    node_type = "BioEntity"
 
     def __init__(self, path: Union[str, Path, None] = None):
         default_path = pystow.join(

--- a/src/indra_cogex/sources/clinicaltrials/__init__.py
+++ b/src/indra_cogex/sources/clinicaltrials/__init__.py
@@ -96,7 +96,7 @@ class ClinicaltrialsProcessor(Processor):
                     yield Node(db_ns="MESH", db_id=mesh_id, labels=["BioEntity"])
 
         for nctid in set(self.tested_in_nct) | set(self.has_trial_nct):
-            yield Node(db_ns="CLINICALTRIALS", db_id=nctid, labels=[])
+            yield Node(db_ns="CLINICALTRIALS", db_id=nctid, labels=["ClinicalTrial"])
 
     def get_relations(self):
         added = set()

--- a/src/indra_cogex/sources/clinicaltrials/__init__.py
+++ b/src/indra_cogex/sources/clinicaltrials/__init__.py
@@ -50,7 +50,7 @@ class ClinicaltrialsProcessor(Processor):
             return matches[0].term
         return None
 
-    def get_nodes(self):
+    def get_nodes(self, **kwargs):
         for index, row in tqdm.tqdm(self.df.iterrows(), total=len(self.df)):
             found_disease_gilda = False
             for condition in str(row["Condition"]).split("|"):

--- a/src/indra_cogex/sources/clinicaltrials/__init__.py
+++ b/src/indra_cogex/sources/clinicaltrials/__init__.py
@@ -50,7 +50,7 @@ class ClinicaltrialsProcessor(Processor):
             return matches[0].term
         return None
 
-    def get_nodes(self, **kwargs):
+    def get_nodes(self):
         for index, row in tqdm.tqdm(self.df.iterrows(), total=len(self.df)):
             found_disease_gilda = False
             for condition in str(row["Condition"]).split("|"):

--- a/src/indra_cogex/sources/clinicaltrials/__init__.py
+++ b/src/indra_cogex/sources/clinicaltrials/__init__.py
@@ -10,7 +10,7 @@ from indra_cogex.representation import Node, Relation
 
 class ClinicaltrialsProcessor(Processor):
     name = "clinicaltrials"
-    node_types = ["BioEntity"]
+    node_types = ["BioEntity", "ClinicalTrial"]
 
     def __init__(self, path: Union[str, Path, None] = None):
         default_path = pystow.join(

--- a/src/indra_cogex/sources/clinicaltrials/__init__.py
+++ b/src/indra_cogex/sources/clinicaltrials/__init__.py
@@ -10,7 +10,7 @@ from indra_cogex.representation import Node, Relation
 
 class ClinicaltrialsProcessor(Processor):
     name = "clinicaltrials"
-    node_type = "BioEntity"
+    node_types = ["BioEntity"]
 
     def __init__(self, path: Union[str, Path, None] = None):
         default_path = pystow.join(

--- a/src/indra_cogex/sources/goa/__init__.py
+++ b/src/indra_cogex/sources/goa/__init__.py
@@ -35,6 +35,7 @@ class GoaProcessor(Processor):
 
     name = "goa"
     df: pd.DataFrame
+    node_type = "BioEntity"
 
     def __init__(self):
         """Initialize the GOA processor."""

--- a/src/indra_cogex/sources/goa/__init__.py
+++ b/src/indra_cogex/sources/goa/__init__.py
@@ -41,7 +41,7 @@ class GoaProcessor(Processor):
         """Initialize the GOA processor."""
         self.df = load_goa(GOA_URL)
 
-    def get_nodes(self):  # noqa:D102
+    def get_nodes(self, **kwargs):  # noqa:D102
         for go_node in self.df["GO_ID"].unique():
             yield Node("GO", go_node, ["BioEntity"])
         for hgnc_id in self.df["HGNC_ID"].unique():

--- a/src/indra_cogex/sources/goa/__init__.py
+++ b/src/indra_cogex/sources/goa/__init__.py
@@ -35,7 +35,7 @@ class GoaProcessor(Processor):
 
     name = "goa"
     df: pd.DataFrame
-    node_type = "BioEntity"
+    node_types = ["BioEntity"]
 
     def __init__(self):
         """Initialize the GOA processor."""

--- a/src/indra_cogex/sources/goa/__init__.py
+++ b/src/indra_cogex/sources/goa/__init__.py
@@ -41,7 +41,7 @@ class GoaProcessor(Processor):
         """Initialize the GOA processor."""
         self.df = load_goa(GOA_URL)
 
-    def get_nodes(self, **kwargs):  # noqa:D102
+    def get_nodes(self):  # noqa:D102
         for go_node in self.df["GO_ID"].unique():
             yield Node("GO", go_node, ["BioEntity"])
         for hgnc_id in self.df["HGNC_ID"].unique():

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -296,6 +296,8 @@ class EvidenceProcessor(Processor):
             yield Relation("indra_evidence", stmt_id, "PUBMED", pmid, "has_citation")
 
     def _dump_nodes(self) -> Path:
+        # This overrides the default implementation in Processor because
+        # we want to process nodes in batches
         # Processing one batch at a time
         for bidx, batch in enumerate(self.get_nodes()):
             logger.info(f"Dumping batch {bidx}")

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -20,6 +20,7 @@ import pystow
 
 from indra.ontology.bio import bio_ontology
 from indra.databases.identifiers import ensure_prefix_if_needed
+from indra.util import batch_iter
 from indra_cogex.representation import Node, Relation
 from indra_cogex.sources.processor import Processor
 
@@ -36,6 +37,7 @@ class DbProcessor(Processor):
 
     name = "database"
     df: pd.DataFrame
+    node_type = "BioEntity"
 
     def __init__(
         self, dir_path: Union[None, str, Path] = None, add_jsons: Optional[bool] = False
@@ -227,6 +229,7 @@ def fix_id(db_ns: str, db_id: str) -> Tuple[str, str]:
 
 class EvidenceProcessor(Processor):
     name = "indra_db_evidence"
+    node_type = "Evidence"
 
     def __init__(self):
         base_path = pystow.module("indra", "cogex", "database")

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -239,12 +239,9 @@ class EvidenceProcessor(Processor):
         self.sif_path = pystow.join("indra", "db", name="sif.pkl")
         self._stmt_id_pmid_links = {}
         # Check if files exist without loading them
-        if not self.statements_path.exists():
-            raise FileNotFoundError(f"No such file: {self.statements_path}")
-        if not self.text_refs_path.exists():
-            raise FileNotFoundError(f"No such file: {self.text_refs_path}")
-        if not self.sif_path.exists():
-            raise FileNotFoundError(f"No such file: {self.sif_path}")
+        for path in [self.statements_path, self.text_refs_path, self.sif_path]:
+            if not path.exists():
+                raise FileNotFoundError(f"No such file: {path}")
 
     def get_nodes(self) -> Iterable[Node]:
         """Get nodes from the SIF file."""

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -230,7 +230,7 @@ def fix_id(db_ns: str, db_id: str) -> Tuple[str, str]:
 
 class EvidenceProcessor(Processor):
     name = "indra_db_evidence"
-    node_type = ["Evidence", "Publication"]
+    node_types = ["Evidence", "Publication"]
 
     def __init__(self):
         base_path = pystow.module("indra", "cogex", "database")

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -251,6 +251,7 @@ class EvidenceProcessor(Processor):
         logger.info("Getting text refs from text refs file")
         with open(self.text_refs_path, "r") as fh:
             text_refs = json.load(fh)
+        logger.info("Getting statements from statements file")  
         with open(self.statements_path, "r") as fh:
             # TODO test whether this is a reasonable size
             batch_size = 100000

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -238,6 +238,13 @@ class EvidenceProcessor(Processor):
         self.text_refs_path = base_path.join(name="text_refs.json")
         self.sif_path = pystow.join("indra", "db", name="sif.pkl")
         self._stmt_id_pmid_links = {}
+        # Check if files exist without loading them
+        if not self.statements_path.exists():
+            raise FileNotFoundError(f"No such file: {self.statements_path}")
+        if not self.text_refs_path.exists():
+            raise FileNotFoundError(f"No such file: {self.text_refs_path}")
+        if not self.sif_path.exists():
+            raise FileNotFoundError(f"No such file: {self.sif_path}")
 
     def get_nodes(self) -> Iterable[Node]:
         """Get nodes from the SIF file."""

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -365,6 +365,17 @@ class EvidenceProcessor(Processor):
         self._dump_nodes_to_path(nodes, nodes_path, sample_path)
         return paths_by_type, dict(nodes_by_type)
 
+    @classmethod
+    def _get_node_paths(cls, node_type: str) -> Path:
+        if node_type == "Publication":
+            return super()._get_node_paths(node_type)
+        elif node_type == "Evidence":
+            return (
+                cls.module.join(name=f"nodes_{node_type}.tsv.gz"),
+                None,
+                cls.module.join(name=f"nodes_{node_type}_sample.tsv"),
+            )
+
 
 class StatementJSONDecodeError(Exception):
     pass

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -287,12 +287,12 @@ class EvidenceProcessor(Processor):
                                 evidence["pmid"],
                                 ["Publication"],
                                 {
-                                    "trid": tr["TRID"],
-                                    "pmcid": tr["PMCID"],
-                                    "doi": tr["DOI"],
-                                    "pii": tr["PII"],
-                                    "url": tr["URL"],
-                                    "manuscript_id": tr["ManuscriptID"],
+                                    "trid": tr.get("TRID"),
+                                    "pmcid": tr.get("PMCID"),
+                                    "doi": tr.get("DOI"),
+                                    "pii": tr.get("PII"),
+                                    "url": tr.get("URL"),
+                                    "manuscript_id": tr.get("ManuscriptID"),
                                 },
                             )
                         else:

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -308,4 +308,5 @@ class EvidenceProcessor(Processor):
                 write_mode = "wt"
             nodes_path = self._dump_nodes_to_path(batch, self.nodes_path,
                                                   sample_path, write_mode)
-        return nodes_path
+        # only the last batch is returned here
+        return nodes_path, batch

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -93,7 +93,7 @@ class DbProcessor(Processor):
         self.df["source_counts"] = self.df["source_counts"].apply(json.dumps)
         self.df = self.df.dropna(subset=["belief"])
 
-    def get_nodes(self):  # noqa:D102
+    def get_nodes(self, **kwargs):  # noqa:D102
         df = pd.concat(
             [
                 self.df[["agA_ns", "agA_id", "agA_name"]].rename(
@@ -238,7 +238,7 @@ class EvidenceProcessor(Processor):
         self.sif_path = pystow.join("indra", "db", name="sif.pkl")
         self._stmt_id_pmid_links = {}
 
-    def get_nodes(self):
+    def get_nodes(self, **kwargs):
         """Get nodes from the SIF file."""
         # Get a list of hashes from the SIF file so that we only
         # add nodes/relations for statements that are in the SIF file

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -264,7 +264,7 @@ class EvidenceProcessor(Processor):
                     else:
                         evidence["pmid"] = None
                 else:
-                    if evidence["pmid"]:
+                    if evidence.get("pmid"):
                         self._stmt_id_pmid_links[raw_stmt_id] = evidence["pmid"]
                 yield Node(
                     "indra_evidence",

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -94,7 +94,7 @@ class DbProcessor(Processor):
         self.df["source_counts"] = self.df["source_counts"].apply(json.dumps)
         self.df = self.df.dropna(subset=["belief"])
 
-    def get_nodes(self, **kwargs):  # noqa:D102
+    def get_nodes(self):  # noqa:D102
         df = pd.concat(
             [
                 self.df[["agA_ns", "agA_id", "agA_name"]].rename(

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -303,7 +303,7 @@ class EvidenceProcessor(Processor):
                 pickle.dump(batch, fh)
             sample_path = None
             # We'll append all batches to a single tsv file
-            write_mode = "a"
+            write_mode = "at"
             if bidx == 0:
                 sample_path = self.module.join(name="nodes_sample.tsv")
                 write_mode = "wt"

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -298,8 +298,16 @@ class EvidenceProcessor(Processor):
                         )
                     yield node_batch
         elif node_type == "Publication":
-            # TODO
-            pass
+            for text_ref in text_refs.values():
+                if "PMID" in text_ref:
+                    data = {
+                        "trid": text_ref.get("TRID"),
+                        "pmcid": text_ref.get("PMCID"),
+                        "doi": text_ref.get("DOI"),
+                        "pii": text_ref.get("PII"),
+                        "manuscript_id": text_ref.get("MANUSCRIPT_ID"),
+                    }
+                    yield Node("PUBMED", text_ref["PMID"], ["Publication"], data=data)
 
     def get_relations(self):
         for stmt_id, pmid in self._stmt_id_pmid_links.items():

--- a/src/indra_cogex/sources/indra_db/__main__.py
+++ b/src/indra_cogex/sources/indra_db/__main__.py
@@ -2,7 +2,8 @@
 
 """Run the INDRA database processor using ``python -m indra_cogex.sources.indra_db``."""
 
-from . import DbProcessor
+from . import DbProcessor, EvidenceProcessor
 
 if __name__ == "__main__":
     DbProcessor.cli()
+    EvidenceProcessor.cli()

--- a/src/indra_cogex/sources/indra_ontology/__init__.py
+++ b/src/indra_cogex/sources/indra_ontology/__init__.py
@@ -18,6 +18,7 @@ class OntologyProcessor(Processor):
 
     name = "ontology"
     ontology: IndraOntology
+    node_type = "BioEntity"
 
     def __init__(self, ontology: Optional[IndraOntology] = None):
         """Initialize the INDRA ontology processor.

--- a/src/indra_cogex/sources/indra_ontology/__init__.py
+++ b/src/indra_cogex/sources/indra_ontology/__init__.py
@@ -33,7 +33,7 @@ class OntologyProcessor(Processor):
             self.ontology = ontology
         self.ontology.initialize()
 
-    def get_nodes(self):  # noqa:D102
+    def get_nodes(self, **kwargs):  # noqa:D102
         for node, data in self.ontology.nodes(data=True):
             db_ns, db_id = self.ontology.get_ns_id(node)
             yield Node(db_ns, db_id, ["BioEntity"], data)

--- a/src/indra_cogex/sources/indra_ontology/__init__.py
+++ b/src/indra_cogex/sources/indra_ontology/__init__.py
@@ -18,7 +18,7 @@ class OntologyProcessor(Processor):
 
     name = "ontology"
     ontology: IndraOntology
-    node_type = "BioEntity"
+    node_types = ["BioEntity"]
 
     def __init__(self, ontology: Optional[IndraOntology] = None):
         """Initialize the INDRA ontology processor.

--- a/src/indra_cogex/sources/indra_ontology/__init__.py
+++ b/src/indra_cogex/sources/indra_ontology/__init__.py
@@ -33,7 +33,7 @@ class OntologyProcessor(Processor):
             self.ontology = ontology
         self.ontology.initialize()
 
-    def get_nodes(self, **kwargs):  # noqa:D102
+    def get_nodes(self):  # noqa:D102
         for node, data in self.ontology.nodes(data=True):
             db_ns, db_id = self.ontology.get_ns_id(node)
             yield Node(db_ns, db_id, ["BioEntity"], data)

--- a/src/indra_cogex/sources/pathways/__init__.py
+++ b/src/indra_cogex/sources/pathways/__init__.py
@@ -30,7 +30,7 @@ class PyoboProcessor(Processor):
     relation: ClassVar[Relation]
     relation_label: ClassVar[str]
     importable = False
-    node_type = "BioEntity"
+    node_types = ["BioEntity"]
 
     def get_nodes(self):  # noqa:D102
         # TODO add license

--- a/src/indra_cogex/sources/pathways/__init__.py
+++ b/src/indra_cogex/sources/pathways/__init__.py
@@ -32,7 +32,7 @@ class PyoboProcessor(Processor):
     importable = False
     node_types = ["BioEntity"]
 
-    def get_nodes(self, **kwargs):  # noqa:D102
+    def get_nodes(self):  # noqa:D102
         # TODO add license
         version = pyobo.api.utils.get_version(self.prefix)
         for identifier, name in pyobo.get_id_name_mapping(self.prefix).items():

--- a/src/indra_cogex/sources/pathways/__init__.py
+++ b/src/indra_cogex/sources/pathways/__init__.py
@@ -32,7 +32,7 @@ class PyoboProcessor(Processor):
     importable = False
     node_types = ["BioEntity"]
 
-    def get_nodes(self):  # noqa:D102
+    def get_nodes(self, **kwargs):  # noqa:D102
         # TODO add license
         version = pyobo.api.utils.get_version(self.prefix)
         for identifier, name in pyobo.get_id_name_mapping(self.prefix).items():

--- a/src/indra_cogex/sources/pathways/__init__.py
+++ b/src/indra_cogex/sources/pathways/__init__.py
@@ -30,6 +30,7 @@ class PyoboProcessor(Processor):
     relation: ClassVar[Relation]
     relation_label: ClassVar[str]
     importable = False
+    node_type = "BioEntity"
 
     def get_nodes(self):  # noqa:D102
         # TODO add license

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -42,6 +42,7 @@ class Processor(ABC):
     nodes_indra_path: ClassVar[Path]
     edges_path: ClassVar[Path]
     importable = True
+    node_type = ClassVar[str]
 
     def __init_subclass__(cls, **kwargs):
         """Initialize the class attributes."""

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -96,7 +96,8 @@ class Processor(ABC):
         return self._dump_nodes_to_path(nodes, self.nodes_path, sample_path), nodes
 
     @staticmethod
-    def _dump_nodes_to_path(nodes: Iterable[Node], nodes_path, sample_path=None):
+    def _dump_nodes_to_path(nodes, nodes_path, sample_path=None,
+                            write_mode="wt"):
         logger.info(f"Dumping into {nodes_path}...")
         nodes = list(validate_nodes(nodes))
         metadata = sorted(set(key for node in nodes for key in node.data))
@@ -110,9 +111,11 @@ class Processor(ABC):
         )
 
         header = "id:ID", ":LABEL", *metadata
-        with gzip.open(nodes_path, mode="wt") as node_file:
+        with gzip.open(nodes_path, mode=write_mode) as node_file:
             node_writer = csv.writer(node_file, delimiter="\t")  # type: ignore
-            node_writer.writerow(header)
+            # Only add header when writing to a new file
+            if write_mode == "wt":
+                node_writer.writerow(header)
             if sample_path:
                 with sample_path.open("w") as node_sample_file:
                     node_sample_writer = csv.writer(node_sample_file, delimiter="\t")

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -90,19 +90,19 @@ class Processor(ABC):
         edge_paths = self._dump_edges()
         return node_paths, nodes, edge_paths
 
-    @staticmethod
-    def _get_node_paths(self, node_type: str) -> Path:
+    @classmethod
+    def _get_node_paths(cls, node_type: str) -> Path:
         # If the processor returns multiple types of nodes, add node_type to the file name
-        if len(self.node_types) > 1:
+        if len(cls.node_types) > 1:
             return (
-                self.module.join(name=f"nodes_{node_type}.tsv.gz"),
-                self.module.join(name=f"nodes_{node_type}.pkl"),
-                self.module.join(name=f"nodes_{node_type}_sample.tsv"),
+                cls.module.join(name=f"nodes_{node_type}.tsv.gz"),
+                cls.module.join(name=f"nodes_{node_type}.pkl"),
+                cls.module.join(name=f"nodes_{node_type}_sample.tsv"),
             )
         return (
-            self.nodes_path,
-            self.nodes_indra_path,
-            self.module.join(name="nodes_sample.tsv"),
+            cls.nodes_path,
+            cls.nodes_indra_path,
+            cls.module.join(name="nodes_sample.tsv"),
         )
 
     def _dump_nodes(self) -> Tuple[Path, List[Node]]:

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -88,7 +88,13 @@ class Processor(ABC):
 
     def _dump_nodes(self) -> Tuple[Path, List[Node]]:
         sample_path = self.module.join(name="nodes_sample.tsv")
-        nodes = sorted(self.get_nodes(), key=lambda x: (x.db_ns, x.db_id))
+        nodes = sorted(
+            [
+                n
+                for n in tqdm(self.get_nodes(), desc="Node generation", unit_scale=True)
+            ],
+            key=lambda x: (x.db_ns, x.db_id),
+        )
         with open(self.nodes_indra_path, "wb") as fh:
             pickle.dump(nodes, fh)
         return self._dump_nodes_to_path(nodes, self.nodes_path, sample_path), nodes
@@ -104,7 +110,7 @@ class Processor(ABC):
                 ";".join(node.labels),
                 *[node.data.get(key, "") for key in metadata],
             )
-            for node in tqdm(nodes, desc="Nodes", unit_scale=True)
+            for node in tqdm(nodes, desc="Node serialization", unit_scale=True)
         )
 
         header = "id:ID", ":LABEL", *metadata

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -202,7 +202,7 @@ class Processor(ABC):
 
 
 def assert_valid_node(
-    db_ns: str, db_id: str, data: Optional[Mapping[str, Any]]
+    db_ns: str, db_id: str, data: Optional[Mapping[str, Any]] = None
 ) -> None:
     if db_ns == "indra_evidence":
         if data and data.get("evidence"):

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -59,7 +59,7 @@ class Processor(ABC):
         cls.edges_path = cls.module.join(name="edges.tsv.gz")
 
     @abstractmethod
-    def get_nodes(self, **kwargs) -> Iterable[Node]:
+    def get_nodes(self) -> Iterable[Node]:
         """Iterate over the nodes to upload."""
 
     @abstractmethod

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -87,6 +87,7 @@ class Processor(ABC):
         edge_paths = self._dump_edges()
         return node_paths, nodes, edge_paths
 
+    @staticmethod
     def _get_node_paths(self, node_type: str) -> Path:
         # If the processor returns multiple types of nodes, add node_type to the file name
         if len(self.node_types) > 1:

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -163,8 +163,11 @@ class Processor(ABC):
 def validate_nodes(nodes: Iterable[Node]) -> Iterable[Node]:
     for idx, node in enumerate(nodes):
         try:
-            assert_valid_db_refs({node.db_ns: node.db_id})
-            yield node
+            if node.db_ns == "indra_evidence":
+                yield node
+            else:
+                assert_valid_db_refs({node.db_ns: node.db_id})
+                yield node
         except Exception as e:
             logger.info(f"{idx}: {node} - {e}")
             continue
@@ -173,9 +176,13 @@ def validate_nodes(nodes: Iterable[Node]) -> Iterable[Node]:
 def validate_relations(relations):
     for idx, rel in enumerate(relations):
         try:
-            assert_valid_db_refs({rel.source_ns: rel.source_id})
-            assert_valid_db_refs({rel.target_ns: rel.target_id})
-            yield rel
+            if rel.source_ns == "indra_evidence":
+                assert_valid_db_refs({rel.target_ns: rel.target_id})
+                yield rel
+            else:
+                assert_valid_db_refs({rel.source_ns: rel.source_id})
+                assert_valid_db_refs({rel.target_ns: rel.target_id})
+                yield rel
         except Exception as e:
             logger.info(f"{idx}: {rel} - {e}")
             continue

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -156,6 +156,7 @@ class Processor(ABC):
         with gzip.open(self.edges_path, mode=write_mode) as edge_file:
             edge_writer = csv.writer(edge_file, delimiter="\t")  # type: ignore
             header = ":START_ID", ":END_ID", ":TYPE", *metadata
+            # Only add header when writing to a new file
             if write_mode == "wt":
                 edge_writer.writerow(header)
             if sample_path:

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -88,13 +88,8 @@ class Processor(ABC):
 
     def _dump_nodes(self) -> Tuple[Path, List[Node]]:
         sample_path = self.module.join(name="nodes_sample.tsv")
-        nodes = sorted(
-            [
-                n
-                for n in tqdm(self.get_nodes(), desc="Node generation", unit_scale=True)
-            ],
-            key=lambda x: (x.db_ns, x.db_id),
-        )
+        nodes = tqdm(self.get_nodes(), desc="Node generation", unit_scale=True, unit="node")
+        nodes = sorted(nodes, key=lambda x: (x.db_ns, x.db_id))
         with open(self.nodes_indra_path, "wb") as fh:
             pickle.dump(nodes, fh)
         return self._dump_nodes_to_path(nodes, self.nodes_path, sample_path), nodes

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -63,7 +63,8 @@ class PubmedProcessor(Processor):
 
     def get_relations(self):
         with open(self.mesh_pmid_path, "r") as fh:
-            reader = csv.reader(fh, delimiter="\t")
+            reader = csv.reader(fh)
+            next(reader)  # skip header
             for mesh_num, is_concept, major_topic, pmid in reader:
                 mesh_id = mesh_num_to_id(mesh_num, is_concept)
                 yield Relation(

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -66,14 +66,14 @@ class PubmedProcessor(Processor):
             reader = csv.reader(fh)
             next(reader)  # skip header
             for mesh_num, is_concept, major_topic, pmid in reader:
-                mesh_id = mesh_num_to_id(mesh_num, is_concept)
+                mesh_id = mesh_num_to_id(mesh_num, int(is_concept))
                 yield Relation(
                     "PUBMED",
                     pmid,
                     "MESH",
                     mesh_id,
                     "annotated_with",
-                    {"is_major_topic": True if major_topic == 1 else False},
+                    {"is_major_topic": True if major_topic == "1" else False},
                 )
 
 

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -32,7 +32,7 @@ class PubmedProcessor(Processor):
         self.pmid_year_path = pmid_year_path
         self.text_refs_path = text_refs_path
 
-    def get_nodes(self):
+    def get_nodes(self, **kwargs):
         pmid_node_type = "Publication"
         logger.info("Loading PMID year info from %s" % self.pmid_year_path)
         with open(self.pmid_year_path, "r") as fh:

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -20,7 +20,7 @@ TEXT_REFS = resources.join(name="text_refs.tsv")
 
 class PubmedProcessor(Processor):
     name = "pubmed"
-    node_type = "Publication"
+    node_types = ["Publication"]
 
     def __init__(
         self,
@@ -73,18 +73,21 @@ class PubmedProcessor(Processor):
             # and each line is lightweight, we could probably try larger batch
             batch_size = 100000
             for batch in tqdm(
-                batch_iter(reader, batch_size=batch_size, return_func=list)):
+                batch_iter(reader, batch_size=batch_size, return_func=list)
+            ):
                 relations_batch = []
                 for mesh_num, is_concept, major_topic, pmid in batch:
                     mesh_id = mesh_num_to_id(mesh_num, int(is_concept))
-                    relations_batch.append(Relation(
-                        "PUBMED",
-                        pmid,
-                        "MESH",
-                        mesh_id,
-                        "annotated_with",
-                        {"is_major_topic": True if major_topic == "1" else False},
-                    ))
+                    relations_batch.append(
+                        Relation(
+                            "PUBMED",
+                            pmid,
+                            "MESH",
+                            mesh_id,
+                            "annotated_with",
+                            {"is_major_topic": True if major_topic == "1" else False},
+                        )
+                    )
                 yield relations_batch
 
     def _dump_edges(self) -> Path:
@@ -97,10 +100,10 @@ class PubmedProcessor(Processor):
             if bidx == 0:
                 sample_path = self.module.join(name="edges_sample.tsv")
                 write_mode = "wt"
-            edges_path = self._dump_edges_to_path(batch, self.edges_path,
-                                                  sample_path, write_mode)
+            edges_path = self._dump_edges_to_path(
+                batch, self.edges_path, sample_path, write_mode
+            )
         return edges_path
-
 
 
 def mesh_num_to_id(mesh_num, is_concept):

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -88,6 +88,8 @@ class PubmedProcessor(Processor):
                 yield relations_batch
 
     def _dump_edges(self) -> Path:
+        # This overrides the default implementation in Processor because
+        # we want to process relations in batches
         for bidx, batch in enumerate(self.get_relations()):
             logger.info(f"Dumping relations batch {bidx}")
             sample_path = None

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -17,6 +17,7 @@ TEXT_REFS = resources.join(name="text_refs.tsv")
 
 class PubmedProcessor(Processor):
     name = "pubmed"
+    node_type = "Publication"
 
     def __init__(
         self,

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -1,0 +1,84 @@
+import csv
+import json
+import logging
+import pystow
+from indra_cogex.representation import Node, Relation
+from indra_cogex.sources.processor import Processor
+
+
+logger = logging.getLogger(__name__)
+
+resources = pystow.module("indra", "cogex", "pubmed")
+
+MESH_PMID = resources.join(name="mesh_pmids.csv")
+PMID_YEAR = resources.join(name="pmid_years_07-2021.json")
+TEXT_REFS = resources.join(name="text_refs.tsv")
+
+
+class PubmedProcessor(Processor):
+    name = "pubmed"
+
+    def __init__(
+        self,
+        mesh_pmid_path=MESH_PMID,
+        pmid_year_path=PMID_YEAR,
+        text_refs_path=TEXT_REFS,
+    ):
+        self.mesh_pmid_path = mesh_pmid_path
+        self.pmid_year_path = pmid_year_path
+        self.text_refs_path = text_refs_path
+
+    def get_nodes(self):
+        # We iterate over text refs to get the nodes and
+        # then look up the year to add as a property
+        pmid_node_type = "Publication"
+        logger.info("Loading PMID year info from %s" % self.pmid_year_path)
+        with open(self.pmid_year_path, "r") as fh:
+            pmid_years = json.load(fh)
+        logger.info("Loaded PMID year info from %s" % self.pmid_year_path)
+
+        with open(self.text_refs_path, "r") as fh:
+            reader = csv.reader(fh, delimiter="\t")
+            for trid, pmid, pmcid, doi, pii, url, manuscript_id in reader:
+                if not pmid:
+                    continue
+                year = pmid_years.get(pmid, None)
+                data = {
+                    "trid": trid,
+                    "pmcid": pmcid,
+                    "doi": doi,
+                    "pii": pii,
+                    "url": url,
+                    "manuscript_id": manuscript_id,
+                    "year": year,
+                }
+                yield Node("PUBMED", pmid, labels=[pmid_node_type], data=data)
+
+    def get_relations(self):
+        with open(self.mesh_pmid_path, "r") as fh:
+            reader = csv.reader(fh, delimiter="\t")
+            for mesh_num, is_concept, major_topic, pmid in reader:
+                mesh_id = mesh_num_to_id(mesh_num, is_concept)
+                yield Relation(
+                    "PUBMED",
+                    pmid,
+                    "MESH",
+                    mesh_id,
+                    "annotated_with",
+                    {"is_major_topic": True if major_topic == 1 else False},
+                )
+
+
+def mesh_num_to_id(mesh_num, is_concept):
+    prefix = "C" if is_concept else "D"
+    if prefix == "D":
+        if int(mesh_num) < 66332:
+            mesh_num = str(mesh_num).zfill(6)
+        else:
+            mesh_num = str(mesh_num).zfill(9)
+    elif prefix == "C":
+        if int(mesh_num) < 588418:
+            mesh_num = str(mesh_num).zfill(6)
+        else:
+            mesh_num = str(mesh_num).zfill(9)
+    return prefix + mesh_num

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -31,6 +31,13 @@ class PubmedProcessor(Processor):
         self.mesh_pmid_path = mesh_pmid_path
         self.pmid_year_path = pmid_year_path
         self.text_refs_path = text_refs_path
+        # Check if the files exist without loading them
+        if not self.mesh_pmid_path.exists():
+            raise FileNotFoundError(f"No such file: {self.mesh_pmid_path}")
+        if not self.pmid_year_path.exists():
+            raise FileNotFoundError(f"No such file: {self.pmid_year_path}")
+        if not self.text_refs_path.exists():
+            raise FileNotFoundError(f"No such file: {self.text_refs_path}")
 
     def get_nodes(self):
         pmid_node_type = "Publication"

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -69,6 +69,8 @@ class PubmedProcessor(Processor):
         with open(self.mesh_pmid_path, "r") as fh:
             reader = csv.reader(fh)
             next(reader)  # skip header
+            # NOTE tested with 100000 batch size but given that total is ~290M
+            # and each line is lightweight, we could probably try larger batch
             batch_size = 100000
             for batch in tqdm(
                 batch_iter(reader, batch_size=batch_size, return_func=list)):

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -37,19 +37,26 @@ class PubmedProcessor(Processor):
             pmid_years = json.load(fh)
         logger.info("Loaded PMID year info from %s" % self.pmid_year_path)
 
+        def get_val(val):
+            # postgres exports \N for missing values
+            if val == "\\N":
+                return None
+            else:
+                return val
+
         with open(self.text_refs_path, "r") as fh:
             reader = csv.reader(fh, delimiter="\t")
             for trid, pmid, pmcid, doi, pii, url, manuscript_id in reader:
-                if not pmid:
+                if not get_val(pmid):
                     continue
                 year = pmid_years.get(pmid, None)
                 data = {
-                    "trid": trid,
-                    "pmcid": pmcid,
-                    "doi": doi,
-                    "pii": pii,
-                    "url": url,
-                    "manuscript_id": manuscript_id,
+                    "trid": get_val(trid),
+                    "pmcid": get_val(pmcid),
+                    "doi": get_val(doi),
+                    "pii": get_val(pii),
+                    "url": get_val(url),
+                    "manuscript_id": get_val(manuscript_id),
                     "year": year,
                 }
                 yield Node("PUBMED", pmid, labels=[pmid_node_type], data=data)

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -29,8 +29,6 @@ class PubmedProcessor(Processor):
         self.text_refs_path = text_refs_path
 
     def get_nodes(self):
-        # We iterate over text refs to get the nodes and
-        # then look up the year to add as a property
         pmid_node_type = "Publication"
         logger.info("Loading PMID year info from %s" % self.pmid_year_path)
         with open(self.pmid_year_path, "r") as fh:
@@ -44,6 +42,8 @@ class PubmedProcessor(Processor):
             else:
                 return val
 
+        # We iterate over text refs to get the nodes and
+        # then look up the year to add as a property
         with open(self.text_refs_path, "r") as fh:
             reader = csv.reader(fh, delimiter="\t")
             for trid, pmid, pmcid, doi, pii, url, manuscript_id in reader:

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -32,7 +32,7 @@ class PubmedProcessor(Processor):
         self.pmid_year_path = pmid_year_path
         self.text_refs_path = text_refs_path
 
-    def get_nodes(self, **kwargs):
+    def get_nodes(self):
         pmid_node_type = "Publication"
         logger.info("Loading PMID year info from %s" % self.pmid_year_path)
         with open(self.pmid_year_path, "r") as fh:

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -70,8 +70,8 @@ class PubmedProcessor(Processor):
             reader = csv.reader(fh)
             next(reader)  # skip header
             # NOTE tested with 100000 batch size but given that total is ~290M
-            # and each line is lightweight, we could probably try larger batch
-            batch_size = 100000
+            # and each line is lightweight, trying with larger batch here
+            batch_size = 1000000
             for batch in tqdm(
                 batch_iter(reader, batch_size=batch_size, return_func=list)
             ):

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -32,12 +32,9 @@ class PubmedProcessor(Processor):
         self.pmid_year_path = pmid_year_path
         self.text_refs_path = text_refs_path
         # Check if the files exist without loading them
-        if not self.mesh_pmid_path.exists():
-            raise FileNotFoundError(f"No such file: {self.mesh_pmid_path}")
-        if not self.pmid_year_path.exists():
-            raise FileNotFoundError(f"No such file: {self.pmid_year_path}")
-        if not self.text_refs_path.exists():
-            raise FileNotFoundError(f"No such file: {self.text_refs_path}")
+        for path in [mesh_pmid_path, pmid_year_path, text_refs_path]:
+            if not path.exists():
+                raise FileNotFoundError(f"No such file: {path}")
 
     def get_nodes(self):
         pmid_node_type = "Publication"

--- a/src/indra_cogex/sources/pubmed/__main__.py
+++ b/src/indra_cogex/sources/pubmed/__main__.py
@@ -1,0 +1,17 @@
+"""Run the PubMed processor using ``python -m indra_cogex.sources.pubmed``."""
+
+import click
+from more_click import verbose_option
+
+from . import PubmedProcessor
+
+
+@click.command()
+@verbose_option
+@click.pass_context
+def _main(ctx: click.Context):
+    ctx.invoke(PubmedProcessor.get_cli())
+
+
+if __name__ == "__main__":
+    _main()

--- a/src/indra_cogex/sources/pubmed/__main__.py
+++ b/src/indra_cogex/sources/pubmed/__main__.py
@@ -1,17 +1,7 @@
 """Run the PubMed processor using ``python -m indra_cogex.sources.pubmed``."""
 
-import click
-from more_click import verbose_option
-
 from . import PubmedProcessor
 
 
-@click.command()
-@verbose_option
-@click.pass_context
-def _main(ctx: click.Context):
-    ctx.invoke(PubmedProcessor.get_cli())
-
-
 if __name__ == "__main__":
-    _main()
+    PubmedProcessor.cli()

--- a/src/indra_cogex/sources/sider/__init__.py
+++ b/src/indra_cogex/sources/sider/__init__.py
@@ -161,7 +161,7 @@ class SIDERSideEffectProcessor(Processor):
                 db_ns=db_ns, db_id=db_id, name=name, labels=["BioEntity"]
             )
 
-    def get_nodes(self) -> Iterable[Node]:
+    def get_nodes(self, **kwargs) -> Iterable[Node]:
         """Iterate over SIDER chemicals and side effects."""
         yield from self.chemicals.values()
         yield from self.side_effects.values()

--- a/src/indra_cogex/sources/sider/__init__.py
+++ b/src/indra_cogex/sources/sider/__init__.py
@@ -117,6 +117,7 @@ class SIDERSideEffectProcessor(Processor):
     """A processor for SIDER side effects."""
 
     name = "sider_side_effects"
+    node_type = "BioEntity"
 
     def __init__(self):
         self.df = SUBMODULE.ensure_csv(

--- a/src/indra_cogex/sources/sider/__init__.py
+++ b/src/indra_cogex/sources/sider/__init__.py
@@ -117,7 +117,7 @@ class SIDERSideEffectProcessor(Processor):
     """A processor for SIDER side effects."""
 
     name = "sider_side_effects"
-    node_type = "BioEntity"
+    node_types = ["BioEntity"]
 
     def __init__(self):
         self.df = SUBMODULE.ensure_csv(

--- a/src/indra_cogex/sources/sider/__init__.py
+++ b/src/indra_cogex/sources/sider/__init__.py
@@ -161,7 +161,7 @@ class SIDERSideEffectProcessor(Processor):
                 db_ns=db_ns, db_id=db_id, name=name, labels=["BioEntity"]
             )
 
-    def get_nodes(self, **kwargs) -> Iterable[Node]:
+    def get_nodes(self) -> Iterable[Node]:
         """Iterate over SIDER chemicals and side effects."""
         yield from self.chemicals.values()
         yield from self.side_effects.values()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -24,7 +24,7 @@ class MockProcessor(Processor):
     """A mock processor."""
 
     name = "mock_processor"
-    node_type = "mock_node"
+    node_types = ["mock_node"]
 
     def __init__(self, key: Optional[str] = None):
         self.key = key or DEFAULT_KEY

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -24,6 +24,7 @@ class MockProcessor(Processor):
     """A mock processor."""
 
     name = "mock_processor"
+    node_type = "mock_node"
 
     def __init__(self, key: Optional[str] = None):
         self.key = key or DEFAULT_KEY

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -69,9 +69,7 @@ class TestCLI(unittest.TestCase):
             MockProcessor.nodes_indra_path = directory / "nodes.pkl"
             MockProcessor.edges_path = directory / "edges.tsv.gz"
 
-            res = runner.invoke(
-                main, args=["--nodes-path", os.path.join(directory, "nodes.tsv")]
-            )
+            res = runner.invoke(main, args=["--process", "--assemble"])
             self.assertEqual(0, res.exit_code, msg=res.exception)
             self.assertIn(SUCCESS_TEXT, res.output)
             self.assertIn(DEFAULT_KEY, res.output)
@@ -101,8 +99,8 @@ class TestCLI(unittest.TestCase):
             res = runner.invoke(
                 main,
                 args=[
-                    "--nodes-path",
-                    os.path.join(directory, "nodes.tsv"),
+                    "--process",
+                    "--assemble",
                     "--config",
                     config_path,
                 ],


### PR DESCRIPTION
This PR makes the following changes:
- Add a new source for PubMed which creates nodes for 30M+ PubMed entries with properties including publication year and other IDs (PMCID, DOI, etc), and relations corresponding to MeSH annotations.
- Add a new source for evidences for INDRA Statements carrying all evidence data and also linked to PubMed nodes
- Refactor import CLI with a more intuitive set of flags and explicitly separating the processing, assembly, and import phases
- Separate node assembly by node type to accommodate multiple node types with distinct assembly groupings