### PR TITLE
Implement higher-level queries

### DIFF
--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -498,7 +498,7 @@ class Neo4jClient:
 
     @staticmethod
     def neo4j_to_relations(neo4j_path: neo4j.graph.Path) -> List[Relation]:
-        """Return a Relation from a neo4j internal single-relation path.
+        """Return a list of Relations from a neo4j internal multi-relation path.
 
         Parameters
         ----------

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -36,6 +36,7 @@ class Neo4jClient:
         self.url = url
         self.driver = GraphDatabase.driver(self.url, auth=auth)
         self.session = None
+        print("hello")
 
     def create_tx(
         self,

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -36,7 +36,6 @@ class Neo4jClient:
         self.url = url
         self.driver = GraphDatabase.driver(self.url, auth=auth)
         self.session = None
-        print("hello")
 
     def create_tx(
         self,

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -1,0 +1,186 @@
+from typing import Iterable, Tuple
+from .neo4j_client import Neo4jClient
+from ..representation import Node
+
+# BGee
+
+
+def get_expressed_genes_in_tissue(
+    client: Neo4jClient, tissue: Tuple[str, str]
+) -> Iterable[Node]:
+    """Return the genes in the given tissue.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    tissue :
+        The tissue to query.
+
+    Returns
+    -------
+    :
+        The genes expressed in the given tissue.
+    """
+    return client.get_sources(tissue, relation="expressed_in")
+
+
+def get_tissues_gene_expressed(client: Neo4jClient, gene: Tuple[str, str]):
+    """Return the tissues the gene is expressed in.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    gene :
+        The gene to query.
+
+    Returns
+    -------
+    :
+        The tissues the gene is expressed in.
+    """
+    return client.get_targets(gene, relation="expressed_in")
+
+
+def is_gene_expressed_in_tissue(
+    client: Neo4jClient, gene: Tuple[str, str], tissue: Tuple[str, str]
+):
+    """Return True if the gene is expressed in the given tissue.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    gene :
+        The gene to query.
+    tissue :
+        The tissue to query.
+
+    Returns
+    -------
+    :
+        True if the gene is expressed in the given tissue.
+    """
+    return client.has_relation(gene, tissue, relation="expressed_in")
+
+
+# GO
+
+
+def get_go_terms_for_gene(client: Neo4jClient, gene: Tuple[str, str]):
+    """Return the GO terms for the given gene.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    gene :
+        The gene to query.
+
+    Returns
+    -------
+    :
+        The GO terms for the given gene.
+    """
+    return client.get_targets(gene, relation="associated_with")
+
+
+def get_genes_for_go_term(
+    client: Neo4jClient, go_term: Tuple[str, str], include_indirect=False
+):
+    """Return the genes associated with the given GO term.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    go_term :
+        The GO term to query.
+
+    Returns
+    -------
+    :
+        The genes associated with the given GO term.
+    """
+    go_children = get_ontology_child_terms(client, go_term) if include_indirect else []
+    gene_nodes = {}
+    for term in [go_term] + go_children:
+        genes = client.get_sources(go_term, relation="associated_with")
+        for gene in genes:
+            gene_nodes[(gene.db_ns, gene.db_id)] = gene
+    return list(gene_nodes.values())
+
+
+def is_go_term_for_gene(
+    client: Neo4jClient, gene: Tuple[str, str], go_term: Tuple[str, str]
+):
+    return client.is_connected(gene, go_term, relation="associated_with")
+
+
+# Trials
+
+
+def get_trials_for_drug(client: Neo4jClient, drug: Tuple[str, str]):
+    return client.get_targets(drug, relation="tested_in")
+
+
+def get_trials_for_disease(client: Neo4jClient, disease: Tuple[str, str]):
+    return client.get_targets(disease, relation="has_trial")
+
+
+def get_drugs_for_trial(client: Neo4jClient, trial: Tuple[str, str]):
+    return client.get_sources(trial, relation="tested_in")
+
+
+def get_diseases_for_trial(client: Neo4jClient, trial: Tuple[str, str]):
+    return client.get_sources(trial, relation="has_trial")
+
+
+# Pathways
+
+
+def get_pathways_for_gene(client: Neo4jClient, gene: Tuple[str, str]):
+    return client.get_targets(gene, relation="has_pathway")
+
+
+def get_genes_for_pathway(client: Neo4jClient, pathway: Tuple[str, str]):
+    return client.get_targets(pathway, relation="haspart")
+
+
+def is_gene_in_pathway(
+    client: Neo4jClient, gene: Tuple[str, str], pathway: Tuple[str, str]
+):
+    return client.has_relation(gene, pathway, relation="haspart")
+
+
+# Side effects
+
+
+def get_side_effects_for_drug(client: Neo4jClient, drug: Tuple[str, str]):
+    return client.get_targets(drug, relation="has_side_effect")
+
+
+def get_drugs_for_side_effect(client: Neo4jClient, side_effect: Tuple[str, str]):
+    return client.get_sources(side_effect, relation="has_side_effect")
+
+
+def is_side_effect_for_drug(
+    client: Neo4jClient, drug: Tuple[str, str], side_effect: Tuple[str, str]
+):
+    return client.has_relation(drug, side_effect, relation="has_side_effect")
+
+
+# Ontology
+
+
+def get_ontology_child_terms(client: Neo4jClient, term: Tuple[str, str]):
+    return client.get_predecessors(term, relations={"is_a", "partof"})
+
+
+def get_ontology_parent_terms(client: Neo4jClient, term: Tuple[str, str]):
+    return client.get_successors(term, relations={"is_a", "partof"})
+
+
+def isa_or_partof(client: Neo4jClient, term: Tuple[str, str], parent: Tuple[str, str]):
+    pass

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -5,9 +5,7 @@ from ..representation import Node
 # BGee
 
 
-def get_expressed_genes_in_tissue(
-    client: Neo4jClient, tissue: Tuple[str, str]
-) -> Iterable[Node]:
+def get_genes_in_tissue(client: Neo4jClient, tissue: Tuple[str, str]) -> Iterable[Node]:
     """Return the genes in the given tissue.
 
     Parameters
@@ -25,7 +23,7 @@ def get_expressed_genes_in_tissue(
     return client.get_sources(tissue, relation="expressed_in")
 
 
-def get_tissues_gene_expressed(client: Neo4jClient, gene: Tuple[str, str]):
+def get_tissues_for_gene(client: Neo4jClient, gene: Tuple[str, str]) -> Iterable[Node]:
     """Return the tissues the gene is expressed in.
 
     Parameters
@@ -43,9 +41,9 @@ def get_tissues_gene_expressed(client: Neo4jClient, gene: Tuple[str, str]):
     return client.get_targets(gene, relation="expressed_in")
 
 
-def is_gene_expressed_in_tissue(
+def is_gene_in_tissue(
     client: Neo4jClient, gene: Tuple[str, str], tissue: Tuple[str, str]
-):
+) -> bool:
     """Return True if the gene is expressed in the given tissue.
 
     Parameters
@@ -70,7 +68,7 @@ def is_gene_expressed_in_tissue(
 
 def get_go_terms_for_gene(
     client: Neo4jClient, gene: Tuple[str, str], include_indirect=False
-):
+) -> Iterable[Node]:
     """Return the GO terms for the given gene.
 
     Parameters
@@ -100,7 +98,7 @@ def get_go_terms_for_gene(
 
 def get_genes_for_go_term(
     client: Neo4jClient, go_term: Tuple[str, str], include_indirect=False
-):
+) -> Iterable[Node]:
     """Return the genes associated with the given GO term.
 
     Parameters
@@ -126,7 +124,7 @@ def get_genes_for_go_term(
 
 def is_go_term_for_gene(
     client: Neo4jClient, gene: Tuple[str, str], go_term: Tuple[str, str]
-):
+) -> bool:
     """Return True if the given GO term is associated with the given gene.
 
     Parameters
@@ -149,66 +147,271 @@ def is_go_term_for_gene(
 # Trials
 
 
-def get_trials_for_drug(client: Neo4jClient, drug: Tuple[str, str]):
+def get_trials_for_drug(client: Neo4jClient, drug: Tuple[str, str]) -> Iterable[Node]:
+    """Return the trials for the given drug.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    drug :
+        The drug to query.
+
+    Returns
+    -------
+    :
+        The trials for the given drug.
+    """
     return client.get_targets(drug, relation="tested_in")
 
 
-def get_trials_for_disease(client: Neo4jClient, disease: Tuple[str, str]):
+def get_trials_for_disease(
+    client: Neo4jClient, disease: Tuple[str, str]
+) -> Iterable[Node]:
+    """Return the trials for the given disease.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    disease :
+        The disease to query.
+
+    Returns
+    -------
+    :
+        The trials for the given disease.
+    """
     return client.get_targets(disease, relation="has_trial")
 
 
-def get_drugs_for_trial(client: Neo4jClient, trial: Tuple[str, str]):
+def get_drugs_for_trial(client: Neo4jClient, trial: Tuple[str, str]) -> Iterable[Node]:
+    """Return the drugs for the given trial.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    trial :
+        The trial to query.
+
+    Returns
+    -------
+    :
+        The drugs for the given trial.
+    """
     return client.get_sources(trial, relation="tested_in")
 
 
-def get_diseases_for_trial(client: Neo4jClient, trial: Tuple[str, str]):
+def get_diseases_for_trial(
+    client: Neo4jClient, trial: Tuple[str, str]
+) -> Iterable[Node]:
+    """Return the diseases for the given trial.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    trial :
+        The trial to query.
+
+    Returns
+    -------
+    :
+        The diseases for the given trial.
+    """
     return client.get_sources(trial, relation="has_trial")
 
 
 # Pathways
 
 
-def get_pathways_for_gene(client: Neo4jClient, gene: Tuple[str, str]):
-    return client.get_targets(gene, relation="has_pathway")
+def get_pathways_for_gene(client: Neo4jClient, gene: Tuple[str, str]) -> Iterable[Node]:
+    """Return the pathways for the given gene.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    gene :
+        The gene to query.
+
+    Returns
+    -------
+    :
+        The pathways for the given gene.
+    """
+    return client.get_targets(gene, relation="haspart")
 
 
-def get_genes_for_pathway(client: Neo4jClient, pathway: Tuple[str, str]):
+def get_genes_for_pathway(
+    client: Neo4jClient, pathway: Tuple[str, str]
+) -> Iterable[Node]:
+    """Return the genes for the given pathway.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    pathway :
+        The pathway to query.
+
+    Returns
+    -------
+    :
+        The genes for the given pathway.
+    """
     return client.get_targets(pathway, relation="haspart")
 
 
 def is_gene_in_pathway(
     client: Neo4jClient, gene: Tuple[str, str], pathway: Tuple[str, str]
-):
+) -> bool:
+    """Return True if the gene is in the given pathway.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    gene :
+        The gene to query.
+    pathway :
+        The pathway to query.
+
+    Returns
+    -------
+    :
+        True if the gene is in the given pathway.
+    """
     return client.has_relation(gene, pathway, relation="haspart")
 
 
 # Side effects
 
 
-def get_side_effects_for_drug(client: Neo4jClient, drug: Tuple[str, str]):
+def get_side_effects_for_drug(
+    client: Neo4jClient, drug: Tuple[str, str]
+) -> Iterable[Node]:
+    """Return the side effects for the given drug.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    drug :
+        The drug to query.
+
+    Returns
+    -------
+    :
+        The side effects for the given drug.
+    """
     return client.get_targets(drug, relation="has_side_effect")
 
 
-def get_drugs_for_side_effect(client: Neo4jClient, side_effect: Tuple[str, str]):
+def get_drugs_for_side_effect(
+    client: Neo4jClient, side_effect: Tuple[str, str]
+) -> Iterable[Node]:
+    """Return the drugs for the given side effect.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    side_effect :
+        The side effect to query.
+
+    Returns
+    -------
+    :
+        The drugs for the given side effect.
+    """
     return client.get_sources(side_effect, relation="has_side_effect")
 
 
 def is_side_effect_for_drug(
     client: Neo4jClient, drug: Tuple[str, str], side_effect: Tuple[str, str]
-):
+) -> bool:
+    """Return True if the given side effect is associated with the given drug.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    drug :
+        The drug to query.
+    side_effect :
+        The side effect to query.
+
+    Returns
+    -------
+    :
+        True if the given side effect is associated with the given drug.
+    """
     return client.has_relation(drug, side_effect, relation="has_side_effect")
 
 
 # Ontology
 
 
-def get_ontology_child_terms(client: Neo4jClient, term: Tuple[str, str]):
+def get_ontology_child_terms(
+    client: Neo4jClient, term: Tuple[str, str]
+) -> Iterable[Node]:
+    """Return the child terms of the given term.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    term :
+        The term to query.
+
+    Returns
+    -------
+    :
+        The child terms of the given term.
+    """
     return client.get_predecessors(term, relations={"isa", "partof"})
 
 
-def get_ontology_parent_terms(client: Neo4jClient, term: Tuple[str, str]):
+def get_ontology_parent_terms(
+    client: Neo4jClient, term: Tuple[str, str]
+) -> Iterable[Node]:
+    """Return the parent terms of the given term.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    term :
+        The term to query.
+
+    Returns
+    -------
+    :
+        The parent terms of the given term.
+    """
     return client.get_successors(term, relations={"isa", "partof"})
 
 
-def isa_or_partof(client: Neo4jClient, term: Tuple[str, str], parent: Tuple[str, str]):
-    pass
+def isa_or_partof(
+    client: Neo4jClient, term: Tuple[str, str], parent: Tuple[str, str]
+) -> bool:
+    """Return True if the given term is a child of the given parent.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    term :
+        The term to query.
+    parent :
+        The parent to query.
+
+    Returns
+    -------
+    :
+        True if the given term is a child term of the given parent.
+    """
+    term_parents = get_ontology_parent_terms(client, term)
+    return any(parent == parent_term.grounding() for parent_term in term_parents)

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -88,7 +88,7 @@ def get_go_terms_for_gene(
         return go_term_nodes
     go_terms = {gtn.grounding(): gtn for gtn in go_term_nodes}
     for go_term_node in go_term_nodes:
-        go_child_terms = client.get_predecessors(
+        go_child_terms = client.get_successors(
             go_term_node.grounding(), relations=["isa"]
         )
         for term in go_child_terms:

--- a/src/indra_cogex/client/subnetwork.py
+++ b/src/indra_cogex/client/subnetwork.py
@@ -1,0 +1,56 @@
+from typing import List, Tuple
+from .queries import get_expressed_genes_in_tissue
+from .neo4j_client import Neo4jClient
+from ..representation import norm_id, Node
+
+
+def indra_subnetwork(client: Neo4jClient, nodes: List[Tuple[str, str]]) -> List[Node]:
+    """Return the INDRA Statement subnetwork induced by the given nodes.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    nodes :
+        The nodes to query.
+
+    Returns
+    -------
+    :
+        The subnetwork induced by the given nodes.
+    """
+    nodes_str = ", ".join(["'%s'" % norm_id(*node) for node in nodes])
+    query = """MATCH p=(n1)-[r:indra_rel]->(n2)
+            WHERE n1.id IN [%s]
+            AND n2.id IN [%s]
+            AND n1.id <> n2.id
+            RETURN r""" % (
+        nodes_str,
+        nodes_str,
+    )
+    res = client.query_tx(query)
+    return res
+
+
+def indra_subnetwork_tissue(
+    client: Neo4jClient, nodes: List[Tuple[str, str]], tissue: Tuple[str, str]
+):
+    """Return the INDRA Statement subnetwork induced by the given nodes and expressed in the given tissue.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    nodes :
+        The nodes to query.
+    tissue :
+        The tissue to query.
+
+    Returns
+    -------
+    :
+        The subnetwork induced by the given nodes and expressed in the given tissue.
+    """
+    genes = get_expressed_genes_in_tissue(client, tissue)
+    relevant_genes = {g.grounding() for g in genes} & set(nodes)
+    return indra_subnetwork(client, relevant_genes)

--- a/src/indra_cogex/client/subnetwork.py
+++ b/src/indra_cogex/client/subnetwork.py
@@ -1,10 +1,13 @@
 from typing import List, Tuple
+from indra.statements import Statement
 from .queries import get_expressed_genes_in_tissue
 from .neo4j_client import Neo4jClient
-from ..representation import norm_id, Node
+from ..representation import norm_id, Node, indra_stmts_from_relations
 
 
-def indra_subnetwork(client: Neo4jClient, nodes: List[Tuple[str, str]]) -> List[Node]:
+def indra_subnetwork(
+    client: Neo4jClient, nodes: List[Tuple[str, str]]
+) -> List[Statement]:
     """Return the INDRA Statement subnetwork induced by the given nodes.
 
     Parameters
@@ -24,17 +27,18 @@ def indra_subnetwork(client: Neo4jClient, nodes: List[Tuple[str, str]]) -> List[
             WHERE n1.id IN [%s]
             AND n2.id IN [%s]
             AND n1.id <> n2.id
-            RETURN r""" % (
+            RETURN p""" % (
         nodes_str,
         nodes_str,
     )
-    res = client.query_tx(query)
-    return res
+    rels = [client.neo4j_to_relation(p[0]) for p in client.query_tx(query)]
+    stmts = indra_stmts_from_relations(rels)
+    return stmts
 
 
 def indra_subnetwork_tissue(
     client: Neo4jClient, nodes: List[Tuple[str, str]], tissue: Tuple[str, str]
-):
+) -> List[Statement]:
     """Return the INDRA Statement subnetwork induced by the given nodes and expressed in the given tissue.
 
     Parameters

--- a/src/indra_cogex/representation.py
+++ b/src/indra_cogex/representation.py
@@ -2,13 +2,15 @@
 
 """Representations for nodes and relations to upload to Neo4j."""
 
-from typing import Any, Collection, Mapping, Optional, Tuple
+from typing import Any, Collection, Iterable, List, Mapping, Optional, Tuple
 
 __all__ = ["Node", "Relation"]
 
+import json
 from indra.databases import identifiers
 from indra.ontology.standardize import standardize_name_db_refs
 from indra.statements.agent import get_grounding
+from indra.statements import stmts_from_json, Statement
 
 
 class Node:
@@ -166,3 +168,23 @@ def norm_id(db_ns, db_id):
         if ns_embedded:
             identifiers_id = identifiers_id[len(identifiers_ns) + 1 :]
     return f"{identifiers_ns}:{identifiers_id}"
+
+
+def indra_stmts_from_relations(rels: Iterable[Relation]) -> List[Statement]:
+    """Convert a list of relations to INDRA Statements.
+
+    Any relations that aren't representing an INDRA Statement are skipped.
+
+    Parameters
+    ----------
+    rels :
+        A list of Relations.
+
+    Returns
+    -------
+    :
+        A list of INDRA Statements.
+    """
+    stmts_json = [json.loads(rel.data["stmt_json"]) for rel in rels]
+    stmts = stmts_from_json(stmts_json)
+    return stmts

--- a/src/indra_cogex/representation.py
+++ b/src/indra_cogex/representation.py
@@ -60,6 +60,10 @@ class Node:
             dict(name=name),
         )
 
+    def grounding(self):
+        """Get the grounding tuple for this node."""
+        return (self.db_ns, self.db_id)
+
     def to_json(self):
         """Serialize the node to JSON."""
         data = {k: v for k, v in self.data.items()}

--- a/tests/test_neo4j_client.py
+++ b/tests/test_neo4j_client.py
@@ -3,7 +3,7 @@ import pytest
 from indra.config import get_config
 from indra.statements import Agent
 
-from indra_cogex.neo4j_client import Neo4jClient, process_identifier
+from indra_cogex.client.neo4j_client import Neo4jClient, process_identifier
 
 
 def _get_client():


### PR DESCRIPTION
This PR moves the `neo4j_client` into a dedicated `client` module and adds a new `queries` module that implements queries with higher-level semantics on top of the generic low-level ones implemented in the client. These queries are useful for analysis workflows and human interaction.