### PR TITLE
MeSH-PubMed extension of mid level queries

### DIFF
--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -658,7 +658,9 @@ def get_stmts_for_pmid(
     return indra_stmts_from_relations(rels)
 
 
-def get_stmts_for_mesh_id(client: Neo4jClient, meshid: Tuple[str, str]) -> Iterable[Statement]:
+def get_stmts_for_mesh_id(
+    client: Neo4jClient, meshid: Tuple[str, str], include_child_terms: bool = True
+) -> Iterable[Statement]:
     """Return the statements with evidence for the given MESH ID.
 
     Parameters
@@ -667,6 +669,8 @@ def get_stmts_for_mesh_id(client: Neo4jClient, meshid: Tuple[str, str]) -> Itera
         The Neo4j client.
     meshid :
         The MESH ID to query.
+    include_child_terms :
+        If True, also match against the children of the given MESH id.
 
     Returns
     -------
@@ -674,23 +678,29 @@ def get_stmts_for_mesh_id(client: Neo4jClient, meshid: Tuple[str, str]) -> Itera
         The statements for the given MESH ID.
     """
     # Get the publications annotated with the given MESH ID
-    pmids = get_pmids_for_mesh(client, meshid)
+    pmids = get_pmids_for_mesh(client, meshid, include_child_terms)
 
     # Get the all evidences for the given pmids
-    pubmed_str = '"' + '","'.join(pmids) + '"'
-    query = """
+    pubmed_str = ",".join(f'"{p}"' for p in pmids)
+    query = (
+        """
         MATCH (e:Evidence)-[r:has_citation]->(n:Publication)
         WHERE n.id IN [%s]
-        RETURN e.stmt_hash
-    """ % pubmed_str
+        RETURN DISTINCT e.stmt_hash
+    """
+        % pubmed_str
+    )
     hashes = [r[0] for r in client.query_tx(query)]
 
     # Then, get the all statements for the given hashes
     stmt_hashes_str = ",".join(hashes)
-    stmts_query = """
-        MATCH p=()-[r:indra_rel]->()
+    stmts_query = (
+        """
+        MATCH p=(:BioEntity)-[r:indra_rel]->(:BioEntity)
         WHERE r.stmt_hash IN [%s]
         RETURN p
-    """ % stmt_hashes_str
+    """
+        % stmt_hashes_str
+    )
     rels = [client.neo4j_to_relation(r[0]) for r in client.query_tx(stmts_query)]
     return indra_stmts_from_relations(rels)

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -385,8 +385,8 @@ def is_gene_in_pathway(
         True if the gene is in the given pathway.
     """
     return client.has_relation(
-        gene,
         pathway,
+        gene,
         relation="haspart",
         source_type="BioEntity",
         target_type="BioEntity",

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -667,9 +667,6 @@ def get_evidence_obj_for_stmt_hashes(
         The Neo4j client.
     stmt_hashes :
         The statement hashes to query.
-    evidence_map :
-        Optionally provide a mapping of stmt hash to a list of evidence
-        objects that can be used to skip querying for evidence objects.
 
     Returns
     -------

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -743,7 +743,9 @@ def get_stmts_for_mesh_id(
 
 
 def get_stmts_for_stmt_hashes(
-    client: Neo4jClient, stmt_hashes: Iterable[str], evidence_map: Dict[str, Evidence] = None
+    client: Neo4jClient,
+    stmt_hashes: Iterable[str],
+    evidence_map: Dict[str, Evidence] = None,
 ) -> Iterable[Statement]:
     """Return the statements for the given statement hashes.
 
@@ -793,16 +795,19 @@ def get_stmts_for_stmt_hashes(
         if ev_list:
             stmt.evidence = ev_list
         else:
-            logger.warning(f'No evidence for stmt hash {stmt_hash}, '
-                           f'keeping sample evidence')
+            logger.warning(
+                f"No evidence for stmt hash {stmt_hash}, keeping sample evidence"
+            )
 
     return list(stmts.values())
 
 
-def _get_ev_dict_from_hash_ev_query(result: Optional[Iterable[List[str]]] = None) -> Dict[str, Evidence]:
+def _get_ev_dict_from_hash_ev_query(
+    result: Optional[Iterable[List[str]]] = None,
+) -> Dict[str, Evidence]:
     """Assumes `result` is an Iterable of pairs of [hash, evidence_json]"""
     if result is None:
-        logger.warning('No result for hash, Evidence query, returning empty dict')
+        logger.warning("No result for hash, Evidence query, returning empty dict")
         return {}
 
     ev_dict = defaultdict(list)

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from collections import defaultdict
-from typing import Iterable, Tuple, Mapping, Dict, List, Optional
+from typing import Iterable, Tuple, Dict, List, Optional
 from indra.statements import Evidence, Statement
 from .neo4j_client import Neo4jClient
 from ..representation import Node, indra_stmts_from_relations, norm_id

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -520,7 +520,8 @@ def get_pmids_for_mesh(
     mesh :
         The MESH term to query.
     include_child_terms :
-        If True, the PubMed IDs for the given MESH term and its child terms
+        If True, also match against the child MESH terms of the given MESH
+        term.
 
     Returns
     -------
@@ -581,11 +582,14 @@ def get_mesh_ids_for_pmid(client: Neo4jClient, pmid: Tuple[str, str]) -> Iterabl
     if pmid[0].lower() != "pmid":
         raise ValueError(f"Expected pmid term, got {':'.join(pmid)}")
 
-    query = """
+    query = (
+        """
         MATCH p=(k:Publication)-[r:annotated_with]->(b:BioEntity)
         WHERE k.id = "%s" AND b.id CONTAINS "mesh"
         RETURN b.id
-    """ % f"pubmed:{pmid[1]}"
+    """
+        % f"pubmed:{pmid[1]}"
+    )
     return [r[0] for r in client.query_tx(query)]
 
 
@@ -606,14 +610,15 @@ def get_evidence_obj_for_stmt_hash(
     :
         The evidence object for the given statement hash.
     """
-    query = """
+    query = (
+        """
         MATCH (n:Evidence)
         WHERE n.stmt_hash = "%s"
         RETURN n.evidence
-    """ % stmt_hash
-    ev_jsons = [
-        json.loads(r[0]) for r in client.query_tx(query)
-    ]
+    """
+        % stmt_hash
+    )
+    ev_jsons = [json.loads(r[0]) for r in client.query_tx(query)]
     return [Evidence._from_json(ev_json) for ev_json in ev_jsons]
 
 
@@ -664,7 +669,7 @@ def get_stmts_for_mesh_id(
     meshid :
         The MESH ID to query.
     include_child_terms :
-        If True, also match against the children of the given MESH id.
+        If True, also match against the children of the given MESH ID.
 
     Returns
     -------

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -522,3 +522,21 @@ def get_pmids_for_mesh(client: Neo4jClient, mesh: Tuple[str, str]) -> Iterable[N
         The PubMed IDs for the given MESH term.
     """
     return client.get_sources(mesh, relation="annotated_with")
+
+
+def get_mesh_ids_for_pmid(client: Neo4jClient, pmid: Tuple[str, str]) -> Iterable[Node]:
+    """Return the MESH terms for the given PubMed ID.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    pmid :
+        The PubMed ID to query.
+
+    Returns
+    -------
+    :
+        The MESH terms for the given PubMed ID.
+    """
+    return client.get_targets(pmid, relation="annotated_with")

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -589,6 +589,9 @@ def get_mesh_ids_for_pmid(client: Neo4jClient, pmid: Tuple[str, str]) -> Iterabl
         raise ValueError(f"Expected pmid term, got {':'.join(pmid)}")
     norm_pmid = norm_id(*pmid)
 
+    # NOTE: we don't need to filter the BioEntity nodes to mesh, since
+    # Publication nodes only have annotated_with relations to BioEntity
+    # nodes that are mesh terms.
     query = (
         """
         MATCH p=(k:Publication)-[r:annotated_with]->(b:BioEntity)
@@ -597,7 +600,7 @@ def get_mesh_ids_for_pmid(client: Neo4jClient, pmid: Tuple[str, str]) -> Iterabl
     """
         % norm_pmid
     )
-    return [r[0] for r in client.query_tx(query) if r[0].startswith("mesh:")]
+    return [r[0] for r in client.query_tx(query)]
 
 
 def get_evidence_obj_for_stmt_hash(

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -664,7 +664,7 @@ def get_evidence_obj_for_stmt_hash(
 
 def get_evidence_obj_for_stmt_hashes(
     client: Neo4jClient, stmt_hashes: Iterable[str]
-) -> Mapping[str, Evidence]:
+) -> Dict[str, List[Evidence]]:
     """Return the matching evidence objects for the given statement hashes.
 
     Parameters
@@ -775,7 +775,7 @@ def get_stmts_for_mesh_id(
 def get_stmts_for_stmt_hashes(
     client: Neo4jClient,
     stmt_hashes: Iterable[str],
-    evidence_map: Dict[str, Evidence] = None,
+    evidence_map: Dict[str, List[Evidence]] = None,
 ) -> Iterable[Statement]:
     """Return the statements for the given statement hashes.
 
@@ -837,7 +837,7 @@ def get_stmts_for_stmt_hashes(
 
 def _get_ev_dict_from_hash_ev_query(
     result: Optional[Iterable[List[str]]] = None,
-) -> Dict[str, Evidence]:
+) -> Dict[str, List[Evidence]]:
     """Assumes `result` is an Iterable of pairs of [hash, evidence_json]"""
     if result is None:
         logger.warning("No result for hash, Evidence query, returning empty dict")

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -770,21 +770,7 @@ def get_stmts_for_mesh_id(
     :
         The statements for the given MESH ID.
     """
-    # Get the publications annotated with the given MESH ID
-    pmid_nodes = get_pmids_for_mesh(client, meshid, include_child_terms)
-
-    # Get the all evidences with their hashes for the given pmids
-    pubmed_str = ",".join(f'"{norm_id(*p.grounding())}"' for p in pmid_nodes)
-    query = (
-        """
-        MATCH (e:Evidence)-[:has_citation]->(n:Publication)
-        WHERE n.id IN [%s]
-        RETURN DISTINCT e.stmt_hash, e.evidence
-    """
-        % pubmed_str
-    )
-    result = client.query_tx(query)
-    ev_dict = _get_ev_dict_from_hash_ev_query(result)
+    ev_dict = get_evidence_obj_for_mesh_id(client, meshid)
     hashes = list(ev_dict.keys())
     return get_stmts_for_stmt_hashes(client, hashes, ev_dict)
 

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -786,6 +786,8 @@ def get_stmts_for_stmt_hashes(
         The Neo4j client.
     stmt_hashes :
         The statement hashes to query.
+    evidence_map :
+        Optionally provide a mapping of stmt hash to a list of evidence objects
 
     Returns
     -------

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -10,6 +10,36 @@ from ..representation import Node, indra_stmts_from_relations, norm_id
 logger = logging.getLogger(__name__)
 
 
+__all__ = [
+    "get_genes_in_tissue",
+    "get_tissues_for_gene",
+    "is_gene_in_tissue",
+    "get_go_terms_for_gene",
+    "get_genes_for_go_term",
+    "is_go_term_for_gene",
+    "get_trials_for_drug",
+    "get_trials_for_disease",
+    "get_drugs_for_trial",
+    "get_diseases_for_trial",
+    "get_pathways_for_gene",
+    "get_genes_for_pathway",
+    "is_gene_in_pathway",
+    "get_side_effects_for_drug",
+    "get_drugs_for_side_effect",
+    "is_side_effect_for_drug",
+    "get_ontology_child_terms",
+    "get_ontology_parent_terms",
+    "isa_or_partof",
+    "get_pmids_for_mesh",
+    "get_mesh_ids_for_pmid",
+    "get_evidence_obj_for_stmt_hash",
+    "get_evidence_objects_for_stmt_hashes",
+    "get_stmts_for_pmid",
+    "get_stmts_for_mesh_id",
+    "get_stmts_for_stmt_hashes",
+]
+
+
 # BGee
 
 

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -501,3 +501,24 @@ def isa_or_partof(
     """
     term_parents = get_ontology_parent_terms(client, term)
     return any(parent == parent_term.grounding() for parent_term in term_parents)
+
+
+# MESH / PMID
+
+
+def get_pmids_for_mesh(client: Neo4jClient, mesh: Tuple[str, str]) -> Iterable[Node]:
+    """Return the PubMed IDs for the given MESH term.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    mesh :
+        The MESH term to query.
+
+    Returns
+    -------
+    :
+        The PubMed IDs for the given MESH term.
+    """
+    return client.get_sources(mesh, relation="annotated_with")

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -590,12 +590,12 @@ def get_mesh_ids_for_pmid(client: Neo4jClient, pmid: Tuple[str, str]) -> Iterabl
     query = (
         """
         MATCH p=(k:Publication)-[r:annotated_with]->(b:BioEntity)
-        WHERE k.id = "%s" AND b.id CONTAINS "mesh"
+        WHERE k.id = "%s"
         RETURN b.id
     """
         % f"pubmed:{pmid[1]}"
     )
-    return [r[0] for r in client.query_tx(query)]
+    return [r[0] for r in client.query_tx(query) if r[0].startswith("mesh:")]
 
 
 def get_evidence_obj_for_stmt_hash(

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -33,7 +33,7 @@ __all__ = [
     "get_pmids_for_mesh",
     "get_mesh_ids_for_pmid",
     "get_evidence_obj_for_stmt_hash",
-    "get_evidence_objects_for_stmt_hashes",
+    "get_evidence_obj_for_stmt_hashes",
     "get_stmts_for_pmid",
     "get_stmts_for_mesh_id",
     "get_stmts_for_stmt_hashes",
@@ -662,7 +662,7 @@ def get_evidence_obj_for_stmt_hash(
     return [Evidence._from_json(ev_json) for ev_json in ev_jsons]
 
 
-def get_evidence_objects_for_stmt_hashes(
+def get_evidence_obj_for_stmt_hashes(
     client: Neo4jClient, stmt_hashes: Iterable[str]
 ) -> Mapping[str, Evidence]:
     """Return the matching evidence objects for the given statement hashes.
@@ -815,7 +815,7 @@ def get_stmts_for_stmt_hashes(
 
     # Get the evidence objects for the given statement hashes
     if missing_hashes:
-        new_evidences = get_evidence_objects_for_stmt_hashes(client, stmt_hashes)
+        new_evidences = get_evidence_obj_for_stmt_hashes(client, stmt_hashes)
         if evidence_map:
             evidence_map.update(new_evidences)
         else:

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -542,7 +542,7 @@ def get_pmids_for_mesh(
     if include_child_terms:
         child_query = (
             """
-            MATCH (c:BioEntity)-[:isa|partf*1..]->(p:BioEntity)
+            MATCH (c:BioEntity)-[:isa*1..]->(p:BioEntity)
             WHERE p.id = "mesh:%s"
             RETURN DISTINCT c.id
             """

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -1,5 +1,6 @@
+import json
 from typing import Iterable, Tuple
-
+from indra.statements import Evidence
 from .neo4j_client import Neo4jClient
 from ..representation import Node
 
@@ -540,3 +541,31 @@ def get_mesh_ids_for_pmid(client: Neo4jClient, pmid: Tuple[str, str]) -> Iterabl
         The MESH terms for the given PubMed ID.
     """
     return client.get_targets(pmid, relation="annotated_with")
+
+
+def get_evidence_obj_for_stmt_hash(
+    client: Neo4jClient, stmt_hash: str
+) -> Iterable[Evidence]:
+    """Return the matching evidence objects for the given statement hash.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    stmt_hash :
+        The statement hash to query.
+
+    Returns
+    -------
+    :
+        The evidence object for the given statement hash.
+    """
+    query = """
+        MATCH (n:Evidence)
+        WHERE n.stmt_hash = '{stmt_hash}'
+        RETURN n.evidence
+    """
+    ev_jsons = [
+        json.loads(r[0]) for r in client.query_tx(query.format(stmt_hash=stmt_hash))
+    ]
+    return [Evidence._from_json(ev_json) for ev_json in ev_jsons]

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -619,9 +619,6 @@ def get_mesh_ids_for_pmid(client: Neo4jClient, pmid: Tuple[str, str]) -> Iterabl
     if pmid[0].lower() != "pubmed":
         raise ValueError(f"Expected pmid term, got {':'.join(pmid)}")
 
-    # NOTE: we don't need to filter the BioEntity nodes to mesh, since
-    # Publication nodes only have annotated_with relations to BioEntity
-    # nodes that are mesh terms.
     return client.get_targets(
         source=pmid,
         relation="annotated_with",
@@ -747,7 +744,7 @@ def get_stmts_for_mesh_id(
     pmid_nodes = get_pmids_for_mesh(client, meshid, include_child_terms)
 
     # Get the all evidences with their hashes for the given pmids
-    pubmed_str = ",".join(f'"{norm_id(p.db_ns, p.db_id)}"' for p in pmid_nodes)
+    pubmed_str = ",".join(f'"{norm_id(*p.grounding())}"' for p in pmid_nodes)
     query = (
         """
         MATCH (e:Evidence)-[:has_citation]->(n:Publication)

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -777,7 +777,8 @@ def get_stmts_for_stmt_hashes(
 
     # If the evidence_map is provided, check if it covers all the hashes
     # and if not, query for the evidence objects
-    if evidence_map is not None:
+    evidence_map = evidence_map or {}
+    if evidence_map:
         missing_hashes = list(set(stmt_hashes) - set(evidence_map.keys()))
     else:
         missing_hashes = stmt_hashes
@@ -785,8 +786,10 @@ def get_stmts_for_stmt_hashes(
     # Get the evidence objects for the given statement hashes
     if missing_hashes:
         new_evidences = get_evidence_objects_for_stmt_hashes(client, stmt_hashes)
-        if evidence_map is not None:
+        if evidence_map:
             evidence_map.update(new_evidences)
+        else:
+            evidence_map = new_evidences
 
     # Add the evidence objects to the statements, if no result, keep the
     # original statement evidence

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -585,8 +585,9 @@ def get_pmids_for_mesh(
     if child_terms:
         terms = {norm_mesh} | child_terms
         terms_str = ",".join(f'"{c}"' for c in terms)
-        match_clause = f"MATCH c.id IN [{terms_str}]"
-        where_clause = "WHERE b.id IN [%s]" % terms_str
+        query = """MATCH (k: Publication)-[r: annotated_with]->(b:BioEntity)
+                   WHERE b.id IN [%s]
+                   RETURN DISTINCT k.id""" % terms_str
     else:
         match_clause = 'MATCH (k: Publication)-[r: annotated_with]->(b:BioEntity {id: "%s"})' % norm_mesh
         query = "%s RETURN k.id" % match_clause

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -32,11 +32,11 @@ __all__ = [
     "isa_or_partof",
     "get_pmids_for_mesh",
     "get_mesh_ids_for_pmid",
-    "get_evidence_obj_for_mesh_id",
-    "get_evidence_obj_for_stmt_hash",
-    "get_evidence_obj_for_stmt_hashes",
+    "get_evidences_for_mesh",
+    "get_evidences_for_stmt_hash",
+    "get_evidences_for_stmt_hashes",
     "get_stmts_for_pmid",
-    "get_stmts_for_mesh_id",
+    "get_stmts_for_mesh",
     "get_stmts_for_stmt_hashes",
 ]
 

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -332,7 +332,7 @@ def get_pathways_for_gene(client: Neo4jClient, gene: Tuple[str, str]) -> Iterabl
     :
         The pathways for the given gene.
     """
-    return client.get_targets(
+    return client.get_sources(
         gene,
         relation="haspart",
         source_type="BioEntity",

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -585,11 +585,17 @@ def get_pmids_for_mesh(
     if child_terms:
         terms = {norm_mesh} | child_terms
         terms_str = ",".join(f'"{c}"' for c in terms)
-        query = """MATCH (k: Publication)-[r: annotated_with]->(b:BioEntity)
+        query = (
+            """MATCH (k: Publication)-[r: annotated_with]->(b:BioEntity)
                    WHERE b.id IN [%s]
-                   RETURN DISTINCT k.id""" % terms_str
+                   RETURN DISTINCT k.id"""
+            % terms_str
+        )
     else:
-        match_clause = 'MATCH (k: Publication)-[r: annotated_with]->(b:BioEntity {id: "%s"})' % norm_mesh
+        match_clause = (
+            'MATCH (k: Publication)-[r: annotated_with]->(b:BioEntity {id: "%s"})'
+            % norm_mesh
+        )
         query = "%s RETURN k.id" % match_clause
 
     return [r[0] for r in client.query_tx(query)]

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from collections import defaultdict
-from typing import Iterable, Tuple, Mapping
+from typing import Iterable, Tuple, Mapping, Dict, List, Optional
 from indra.statements import Evidence, Statement
 from .neo4j_client import Neo4jClient
 from ..representation import Node, indra_stmts_from_relations, norm_id
@@ -781,3 +781,16 @@ def get_stmts_for_stmt_hashes(
                            f'keeping sample evidence')
 
     return list(stmts.values())
+
+
+def _get_ev_dict_from_hash_ev_query(result: Optional[Iterable[List[str]]] = None) -> Dict[str, Evidence]:
+    """Assumes the result is an Iterable of pairs of [hash, evidence_json]"""
+    if result is None:
+        logger.warning('No result for hash, Evidence query, returning empty dict')
+        return {}
+
+    ev_dict = defaultdict(list)
+    for hash_str, ev_json_str in result:
+        ev_json = json.loads(ev_json_str)
+        ev_dict[hash_str].append(Evidence._from_json(ev_json))
+    return dict(ev_dict)

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -612,7 +612,7 @@ def get_mesh_ids_for_pmid(
     :
         The MESH terms for the given PubMed ID.
     """
-    if pmid_term[0] == "PUBMED":
+    if pmid_term[0] != "PUBMED":
         raise ValueError(f"Expected PUBMED term, got %s" % str(pmid_term))
 
     return client.get_targets(

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -644,7 +644,7 @@ def get_evidence_objects_for_stmt_hashes(
     Returns
     -------
     :
-        A tuple of the stmt hash and an evidence objects for the given
+        A mapping of stmt hash to a list of evidence objects for the given
         statement hashes.
     """
     stmt_hashes_str = ",".join(f'"{h}"' for h in stmt_hashes)

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -529,10 +529,10 @@ def get_pmids_for_mesh(client: Neo4jClient, mesh: Tuple[str, str]) -> Iterable[s
         raise ValueError(f"Expected mesh term, got {':'.join(mesh)}")
     query = """
         MATCH p=(k:Publication)-[r:annotated_with]->(b:BioEntity)
-        WHERE b.id = "{mesh}"
+        WHERE b.id = "%s"
         RETURN k.id
-    """
-    return [r[0] for r in client.query_tx(query.format(mesh=f"mesh:{mesh[1]}"))]
+    """ % f"mesh:{mesh[1]}"
+    return [r[0] for r in client.query_tx(query)]
 
 
 def get_mesh_ids_for_pmid(client: Neo4jClient, pmid: Tuple[str, str]) -> Iterable[Node]:
@@ -572,11 +572,11 @@ def get_evidence_obj_for_stmt_hash(
     """
     query = """
         MATCH (n:Evidence)
-        WHERE n.stmt_hash = '{stmt_hash}'
+        WHERE n.stmt_hash = "%s"
         RETURN n.evidence
-    """
+    """ % stmt_hash
     ev_jsons = [
-        json.loads(r[0]) for r in client.query_tx(query.format(stmt_hash=stmt_hash))
+        json.loads(r[0]) for r in client.query_tx(query)
     ]
     return [Evidence._from_json(ev_json) for ev_json in ev_jsons]
 

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -797,7 +797,7 @@ def get_stmts_for_stmt_hashes(
 
 
 def _get_ev_dict_from_hash_ev_query(result: Optional[Iterable[List[str]]] = None) -> Dict[str, Evidence]:
-    """Assumes the result is an Iterable of pairs of [hash, evidence_json]"""
+    """Assumes `result` is an Iterable of pairs of [hash, evidence_json]"""
     if result is None:
         logger.warning('No result for hash, Evidence query, returning empty dict')
         return {}

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -585,7 +585,7 @@ def get_mesh_ids_for_pmid(client: Neo4jClient, pmid: Tuple[str, str]) -> Iterabl
     :
         The MESH terms for the given PubMed ID.
     """
-    if pmid[0].lower() != "pmid":
+    if pmid[0].lower() != "pubmed":
         raise ValueError(f"Expected pmid term, got {':'.join(pmid)}")
     norm_pmid = norm_id(*pmid)
 

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -545,7 +545,7 @@ def isa_or_partof(
 
 
 def get_pmids_for_mesh(
-    client: Neo4jClient, mesh: Tuple[str, str], include_child_terms: bool = True
+    client: Neo4jClient, meshid: Tuple[str, str], include_child_terms: bool = True
 ) -> Iterable[Node]:
     """Return the PubMed IDs for the given MESH term.
 
@@ -553,7 +553,7 @@ def get_pmids_for_mesh(
     ----------
     client :
         The Neo4j client.
-    mesh :
+    meshid :
         The MESH term to query.
     include_child_terms :
         If True, also match against the child MESH terms of the given MESH
@@ -564,15 +564,15 @@ def get_pmids_for_mesh(
     :
         The PubMed IDs for the given MESH term and, optionally, its child terms.
     """
-    if mesh[0].lower() != "mesh":
-        raise ValueError(f"Expected mesh term, got {':'.join(mesh)}")
-    norm_mesh = norm_id(*mesh)
+    if meshid[0].lower() != "mesh":
+        raise ValueError(f"Expected mesh term, got {':'.join(meshid)}")
+    norm_mesh = norm_id(*meshid)
 
     # NOTE: we could use get_ontology_child_terms() here, but it's ~20 times
     # slower for this specific query, so we do an optimized query that is
     # basically equivalent instead.
     if include_child_terms:
-        child_terms = _get_mesh_child_terms(client, mesh)
+        child_terms = _get_mesh_child_terms(client, meshid)
     else:
         child_terms = set()
 
@@ -622,7 +622,7 @@ def get_mesh_ids_for_pmid(client: Neo4jClient, pmid: Tuple[str, str]) -> Iterabl
 
 
 def get_evidence_obj_for_mesh_id(
-    client: Neo4jClient, mesh: Tuple[str, str], include_child_terms: bool = True
+    client: Neo4jClient, meshid: Tuple[str, str], include_child_terms: bool = True
 ) -> Dict[str, List[Evidence]]:
     """Return the evidence objects for the given MESH term.
 
@@ -630,7 +630,7 @@ def get_evidence_obj_for_mesh_id(
     ----------
     client :
         The Neo4j client.
-    mesh :
+    meshid :
         The MESH ID to query.
     include_child_terms :
         If True, also match against the child MESH terms of the given MESH ID
@@ -640,12 +640,12 @@ def get_evidence_obj_for_mesh_id(
     :
         The evidence objects for the given MESH ID.
     """
-    if mesh[0].lower() != "mesh":
-        raise ValueError(f"Expected mesh term, got {':'.join(mesh)}")
+    if meshid[0].lower() != "mesh":
+        raise ValueError(f"Expected mesh term, got {':'.join(meshid)}")
 
-    norm_mesh = norm_id(*mesh)
+    norm_mesh = norm_id(*meshid)
     if include_child_terms:
-        child_terms = _get_mesh_child_terms(client, mesh)
+        child_terms = _get_mesh_child_terms(client, meshid)
     else:
         child_terms = set()
 

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -599,7 +599,7 @@ def get_stmts_for_pmid(
         WHERE n.id = 'pubmed:{pmid}'
         RETURN s.stmt_hash
     """
-    hashes = [r[0] for r in client.query_tx(hash_query.format(pmid=pmid))]
+    hashes = [r[0] for r in client.query_tx(hash_query.format(pmid=pmid[1]))]
 
     # Then, get the all statements for the given hashes
     stmt_hashes_str = ",".join(hashes)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -11,7 +11,7 @@ def test_get_genes_in_tissue():
     # Single query
     client = _get_client()
     genes = get_genes_in_tissue(client, ("UBERON", "UBERON:0002349"))
-    assert len(genes)
+    assert genes
     node0 = genes[0]
     assert isinstance(node0, Node)
     assert node0.db_ns == "HGNC"
@@ -22,10 +22,10 @@ def test_get_tissues_for_gene():
     # Single query
     client = _get_client()
     tissues = get_tissues_for_gene(client, ("HGNC", "9896"))
-    assert len(tissues)
+    assert tissues
     node0 = tissues[0]
     assert isinstance(node0, Node)
-    assert node0.db_ns == "UBERON"
+    assert node0.db_ns in {"UBERON", "CL"}
 
 
 @pytest.mark.nonpublic
@@ -41,7 +41,7 @@ def test_get_go_terms_for_gene():
     client = _get_client()
     gene = ("HGNC", "16813")  # PPP1R27
     go_terms = get_go_terms_for_gene(client, gene)
-    assert len(go_terms)
+    assert go_terms
     node0 = go_terms[0]
     assert isinstance(node0, Node)
     assert node0.db_ns == "GO"
@@ -53,7 +53,7 @@ def test_get_genes_for_go_term():
     client = _get_client()
     go_term = ("GO", "GO:0000978")
     genes = get_genes_for_go_term(client, go_term)
-    assert len(genes)
+    assert genes
     node0 = genes[0]
     assert isinstance(node0, Node)
     assert node0.db_ns == "HGNC"
@@ -73,7 +73,7 @@ def test_get_trials_for_drug():
     client = _get_client()
     drug = ("CHEBI", "CHEBI:27690")
     trials = get_trials_for_drug(client, drug)
-    assert len(trials)
+    assert trials
     assert isinstance(trials[0], Node)
     assert trials[0].db_ns == "CLINICALTRIALS"
 
@@ -83,7 +83,7 @@ def test_get_trials_for_disease():
     client = _get_client()
     disease = ("MESH", "D007855")
     trials = get_trials_for_disease(client, disease)
-    assert len(trials)
+    assert trials
     assert isinstance(trials[0], Node)
     assert trials[0].db_ns == "CLINICALTRIALS"
 
@@ -93,7 +93,7 @@ def test_get_drugs_for_trial():
     client = _get_client()
     trial = ("CLINICALTRIALS", "NCT00000114")
     drugs = get_drugs_for_trial(client, trial)
-    assert len(drugs)
+    assert drugs
     assert drugs[0].db_ns in ["CHEBI", "MESH"]
 
 
@@ -102,7 +102,7 @@ def test_get_diseases_for_trial():
     client = _get_client()
     trial = ("CLINICALTRIALS", "NCT00000114")
     diseases = get_diseases_for_trial(client, trial)
-    assert len(diseases)
+    assert diseases
     assert isinstance(diseases[0], Node)
     assert diseases[0].db_ns == "MESH"
 
@@ -112,9 +112,9 @@ def test_get_pathways_for_gene():
     client = _get_client()
     gene = ("HGNC", "16812")
     pathways = get_pathways_for_gene(client, gene)
-    assert len(pathways)
+    assert pathways
     assert isinstance(pathways[0], Node)
-    assert pathways[0].db_ns == "WIKIPATHWAYS"
+    assert pathways[0].db_ns in {"WIKIPATHWAYS", "REACTOME"}
 
 
 @pytest.mark.nonpublic
@@ -122,7 +122,7 @@ def test_get_genes_for_pathway():
     client = _get_client()
     pathway = ("WIKIPATHWAYS", "WP5037")
     genes = get_genes_for_pathway(client, pathway)
-    assert len(genes)
+    assert genes
     assert isinstance(genes[0], Node)
     assert genes[0].db_ns == "HGNC"
 
@@ -140,7 +140,7 @@ def test_get_side_effects_for_drug():
     client = _get_client()
     drug = ("CHEBI", "CHEBI:29108")
     side_effects = get_side_effects_for_drug(client, drug)
-    assert len(side_effects)
+    assert side_effects
     assert isinstance(side_effects[0], Node)
     assert side_effects[0].db_ns in ["GO", "UMLS", "MESH", "HP"]
 
@@ -150,7 +150,7 @@ def test_get_drugs_for_side_effect():
     client = _get_client()
     side_effect = ("UMLS", "C3267206")
     drugs = get_drugs_for_side_effect(client, side_effect)
-    assert len(drugs)
+    assert drugs
     assert isinstance(drugs[0], Node)
     assert drugs[0].db_ns in ["CHEBI", "MESH"]
 
@@ -168,7 +168,7 @@ def test_get_ontology_child_terms():
     client = _get_client()
     term = ("MESH", "D007855")
     children = get_ontology_child_terms(client, term)
-    assert len(children)
+    assert children
     assert isinstance(children[0], Node)
     assert children[0].db_ns == "MESH"
 
@@ -178,7 +178,7 @@ def test_get_ontology_parent_terms():
     client = _get_client()
     term = ("MESH", "D020263")
     parents = get_ontology_parent_terms(client, term)
-    assert len(parents)
+    assert parents
     assert isinstance(parents[0], Node)
     assert parents[0].db_ns == "MESH"
 
@@ -196,7 +196,7 @@ def test_get_pmids_for_mesh():
     # Single query
     client = _get_client()
     pmids = get_pmids_for_mesh(client, ("MESH", "D015002"))
-    assert len(pmids)
+    assert pmids
     assert isinstance(pmids[0], Node)
     assert pmids[0].db_ns == "PUBMED"
 
@@ -207,7 +207,7 @@ def test_get_mesh_ids_for_pmid():
     client = _get_client()
     pmid = ("PUBMED", "27890007")
     mesh_ids = get_mesh_ids_for_pmid(client, pmid)
-    assert len(mesh_ids)
+    assert mesh_ids
     assert isinstance(mesh_ids[0], Node)
     assert mesh_ids[0].db_ns == "MESH"
 
@@ -216,7 +216,7 @@ def test_get_mesh_ids_for_pmid():
 def test_get_evidence_obj_for_mesh_id():
     client = _get_client()
     mesh_id = ("MESH", "D015002")
-    evidence_dict = get_evidence_obj_for_mesh_id(client, mesh_id)
+    evidence_dict = get_evidences_for_mesh(client, mesh_id)
     assert len(evidence_dict)
     assert isinstance(list(evidence_dict.values())[0][0], Evidence)
 
@@ -227,8 +227,8 @@ def test_get_evidence_obj_for_stmt_hash():
     # Single query
     stmt_hash = "12198579805553967"
     client = _get_client()
-    ev_objs = get_evidence_obj_for_stmt_hash(client, stmt_hash)
-    assert len(ev_objs)
+    ev_objs = get_evidences_for_stmt_hash(client, stmt_hash)
+    assert ev_objs
     assert isinstance(ev_objs[0], Evidence)
 
 
@@ -238,11 +238,11 @@ def test_get_evidence_obj_for_stmt_hashes():
     # Single query
     stmt_hashes = ["12198579805553967", "30651649296901235"]
     client = _get_client()
-    ev_dict = get_evidence_obj_for_stmt_hashes(client, stmt_hashes)
-    assert len(ev_dict)
+    ev_dict = get_evidences_for_stmt_hashes(client, stmt_hashes)
+    assert ev_dict
     assert set(ev_dict.keys()) == {"12198579805553967", "30651649296901235"}
-    assert len(ev_dict["12198579805553967"])
-    assert len(ev_dict["30651649296901235"])
+    assert ev_dict["12198579805553967"]
+    assert ev_dict["30651649296901235"]
     assert isinstance(ev_dict["12198579805553967"][0], Evidence)
     assert isinstance(ev_dict["30651649296901235"][0], Evidence)
 
@@ -253,7 +253,7 @@ def test_get_stmts_for_pmid():
     client = _get_client()
     pmid = ("PUBMED", "14898026")
     stmts = get_stmts_for_pmid(client, pmid)
-    assert len(stmts)
+    assert stmts
     assert isinstance(stmts[0], Inhibition)
 
 
@@ -264,8 +264,8 @@ def test_get_stmts_for_mesh_id_w_children():
     # 2. statements for the evidences in 2
     client = _get_client()
     mesh_id = ("MESH", "D000068236")
-    stmts = get_stmts_for_mesh_id(client, mesh_id)
-    assert len(stmts)
+    stmts = get_stmts_for_mesh(client, mesh_id)
+    assert stmts
     assert isinstance(stmts[0], Activation)
 
 
@@ -276,8 +276,8 @@ def test_get_stmts_for_mesh_id_wo_children():
     # 2. statements for the evidences in 2
     client = _get_client()
     mesh_id = ("MESH", "D000068236")
-    stmts = get_stmts_for_mesh_id(client, mesh_id, include_child_terms=False)
-    assert len(stmts)
+    stmts = get_stmts_for_mesh(client, mesh_id, include_child_terms=False)
+    assert stmts
     assert isinstance(stmts[0], Activation)
 
 
@@ -288,5 +288,5 @@ def test_get_stmts_by_hashes():
     stmt_hashes = ["35279776755000170"]
     client = _get_client()
     stmts = get_stmts_for_stmt_hashes(client, stmt_hashes)
-    assert len(stmts)
+    assert stmts
     assert isinstance(stmts[0], Inhibition)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -15,6 +15,15 @@ def test_get_pmids_for_mesh():
 
 
 @pytest.mark.nonpublic
+def test_get_mesh_ids_for_pmid():
+    client = _get_client()
+    pmid = ("PUBMED", "27890007")
+    mesh_ids = get_mesh_ids_for_pmid(client, pmid)
+    assert len(mesh_ids) == 4
+    assert mesh_ids[0].startswith('mesh:')
+
+
+@pytest.mark.nonpublic
 def test_get_stmts_by_hashes():
     # Note This statement has a 100s of evidences
     # Two queries: first statements, then all the evidence for the statements
@@ -23,4 +32,3 @@ def test_get_stmts_by_hashes():
     stmts = get_stmts_for_stmt_hashes(client, stmt_hashes)
     assert len(stmts) == 1
     assert isinstance(stmts[0], Inhibition)
-

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -14,7 +14,7 @@ def test_get_genes_in_tissue():
     assert len(genes)
     node0 = genes[0]
     assert isinstance(node0, Node)
-    assert node0.db_ns == 'HGNC'
+    assert node0.db_ns == "HGNC"
 
 
 @pytest.mark.nonpublic
@@ -25,7 +25,7 @@ def test_get_tissues_for_gene():
     assert len(tissues)
     node0 = tissues[0]
     assert isinstance(node0, Node)
-    assert node0.db_ns == 'UBERON'
+    assert node0.db_ns == "UBERON"
 
 
 @pytest.mark.nonpublic
@@ -44,7 +44,7 @@ def test_get_go_terms_for_gene():
     assert len(go_terms)
     node0 = go_terms[0]
     assert isinstance(node0, Node)
-    assert node0.db_ns == 'GO'
+    assert node0.db_ns == "GO"
 
 
 @pytest.mark.nonpublic
@@ -56,7 +56,7 @@ def test_get_genes_for_go_term():
     assert len(genes)
     node0 = genes[0]
     assert isinstance(node0, Node)
-    assert node0.db_ns == 'HGNC'
+    assert node0.db_ns == "HGNC"
 
 
 @pytest.mark.nonpublic
@@ -75,7 +75,7 @@ def test_get_trials_for_drug():
     trials = get_trials_for_drug(client, drug)
     assert len(trials)
     assert isinstance(trials[0], Node)
-    assert trials[0].db_ns == 'CLINICALTRIALS'
+    assert trials[0].db_ns == "CLINICALTRIALS"
 
 
 @pytest.mark.nonpublic
@@ -85,7 +85,7 @@ def test_get_trials_for_disease():
     trials = get_trials_for_disease(client, disease)
     assert len(trials)
     assert isinstance(trials[0], Node)
-    assert trials[0].db_ns == 'CLINICALTRIALS'
+    assert trials[0].db_ns == "CLINICALTRIALS"
 
 
 @pytest.mark.nonpublic
@@ -94,7 +94,7 @@ def test_get_drugs_for_trial():
     trial = ("CLINICALTRIALS", "NCT00000114")
     drugs = get_drugs_for_trial(client, trial)
     assert len(drugs)
-    assert drugs[0].db_ns in ['CHEBI', 'MESH']
+    assert drugs[0].db_ns in ["CHEBI", "MESH"]
 
 
 @pytest.mark.nonpublic
@@ -104,7 +104,7 @@ def test_get_diseases_for_trial():
     diseases = get_diseases_for_trial(client, trial)
     assert len(diseases)
     assert isinstance(diseases[0], Node)
-    assert diseases[0].db_ns == 'MESH'
+    assert diseases[0].db_ns == "MESH"
 
 
 @pytest.mark.nonpublic
@@ -114,7 +114,7 @@ def test_get_pathways_for_gene():
     pathways = get_pathways_for_gene(client, gene)
     assert len(pathways)
     assert isinstance(pathways[0], Node)
-    assert pathways[0].db_ns == 'WIKIPATHWAYS'
+    assert pathways[0].db_ns == "WIKIPATHWAYS"
 
 
 @pytest.mark.nonpublic
@@ -124,7 +124,7 @@ def test_get_genes_for_pathway():
     genes = get_genes_for_pathway(client, pathway)
     assert len(genes)
     assert isinstance(genes[0], Node)
-    assert genes[0].db_ns == 'HGNC'
+    assert genes[0].db_ns == "HGNC"
 
 
 @pytest.mark.nonpublic
@@ -142,7 +142,7 @@ def test_get_side_effects_for_drug():
     side_effects = get_side_effects_for_drug(client, drug)
     assert len(side_effects)
     assert isinstance(side_effects[0], Node)
-    assert side_effects[0].db_ns in ['GO', 'UMLS', 'MESH', 'HP']
+    assert side_effects[0].db_ns in ["GO", "UMLS", "MESH", "HP"]
 
 
 @pytest.mark.nonpublic
@@ -152,7 +152,7 @@ def test_get_drugs_for_side_effect():
     drugs = get_drugs_for_side_effect(client, side_effect)
     assert len(drugs)
     assert isinstance(drugs[0], Node)
-    assert drugs[0].db_ns in ['CHEBI', 'MESH']
+    assert drugs[0].db_ns in ["CHEBI", "MESH"]
 
 
 @pytest.mark.nonpublic
@@ -170,7 +170,7 @@ def test_get_ontology_child_terms():
     children = get_ontology_child_terms(client, term)
     assert len(children)
     assert isinstance(children[0], Node)
-    assert children[0].db_ns == 'MESH'
+    assert children[0].db_ns == "MESH"
 
 
 @pytest.mark.nonpublic
@@ -180,7 +180,7 @@ def test_get_ontology_parent_terms():
     parents = get_ontology_parent_terms(client, term)
     assert len(parents)
     assert isinstance(parents[0], Node)
-    assert parents[0].db_ns == 'MESH'
+    assert parents[0].db_ns == "MESH"
 
 
 @pytest.mark.nonpublic
@@ -195,9 +195,9 @@ def test_isa_or_partof():
 def test_get_pmids_for_mesh():
     # Single query
     client = _get_client()
-    pmids = get_pmids_for_mesh(client, ('MESH', 'D015002'))
+    pmids = get_pmids_for_mesh(client, ("MESH", "D015002"))
     assert len(pmids)
-    assert pmids[0].startswith('pubmed:')
+    assert pmids[0].startswith("pubmed:")
 
 
 @pytest.mark.nonpublic
@@ -207,14 +207,14 @@ def test_get_mesh_ids_for_pmid():
     pmid = ("PUBMED", "27890007")
     mesh_ids = get_mesh_ids_for_pmid(client, pmid)
     assert len(mesh_ids)
-    assert mesh_ids[0].startswith('mesh:')
+    assert mesh_ids[0].startswith("mesh:")
 
 
 @pytest.mark.nonpublic
 def test_get_evidence_obj_for_stmt_hash():
     # Note: This statement has a ~500 evidences
     # Single query
-    stmt_hash = '35279776755000170'
+    stmt_hash = "35279776755000170"
     client = _get_client()
     ev_objs = get_evidence_obj_for_stmt_hash(client, stmt_hash)
     assert len(ev_objs)
@@ -225,13 +225,13 @@ def test_get_evidence_obj_for_stmt_hash():
 def test_get_evidence_obj_for_stmt_hashes():
     # Note: This statement has ~500 of evidences
     # Single query
-    stmt_hashes = ['35279776755000170']
+    stmt_hashes = ["35279776755000170"]
     client = _get_client()
     ev_dict = get_evidence_obj_for_stmt_hashes(client, stmt_hashes)
     assert len(ev_dict)
-    assert list(ev_dict.keys())[0] == '35279776755000170'
-    assert len(ev_dict['35279776755000170'])
-    assert isinstance(ev_dict['35279776755000170'][0], Evidence)
+    assert list(ev_dict.keys())[0] == "35279776755000170"
+    assert len(ev_dict["35279776755000170"])
+    assert isinstance(ev_dict["35279776755000170"][0], Evidence)
 
 
 @pytest.mark.nonpublic
@@ -261,7 +261,7 @@ def test_get_stmts_for_mesh_id():
 def test_get_stmts_by_hashes():
     # Note: This statement has a ~500 of evidences
     # Two queries: first statements, then all the evidence for the statements
-    stmt_hashes = ['35279776755000170']
+    stmt_hashes = ["35279776755000170"]
     client = _get_client()
     stmts = get_stmts_for_stmt_hashes(client, stmt_hashes)
     assert len(stmts)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -259,10 +259,9 @@ def test_get_stmts_for_pmid():
 
 @pytest.mark.nonpublic
 def test_get_stmts_for_mesh_id():
-    # Three queries:
-    # 1. pmids with annotation
-    # 2. evidences for publications with pmid in pmids from 1
-    # 3. statements for the evidences in 2
+    # Two queries:
+    # 1. evidences for publications with pmid having mesh annotation
+    # 2. statements for the evidences in 2
     client = _get_client()
     mesh_id = ("MESH", "D000068236")
     stmts = get_stmts_for_mesh_id(client, mesh_id)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,0 +1,26 @@
+import pytest
+from indra_cogex.client.queries import *
+from indra.statements import Inhibition
+
+from .test_neo4j_client import _get_client
+
+
+@pytest.mark.nonpublic
+def test_get_pmids_for_mesh():
+    # Single query
+    client = _get_client()
+    pmids = get_pmids_for_mesh(client, ('MESH', 'D015002'))
+    assert len(pmids) == 1591
+    assert pmids[0].startswith('pubmed:')
+
+
+@pytest.mark.nonpublic
+def test_get_stmts_by_hashes():
+    # Note This statement has a 100s of evidences
+    # Two queries: first statements, then all the evidence for the statements
+    stmt_hashes = ['35279776755000170']
+    client = _get_client()
+    stmts = get_stmts_for_stmt_hashes(client, stmt_hashes)
+    assert len(stmts) == 1
+    assert isinstance(stmts[0], Inhibition)
+

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,6 +1,6 @@
 import pytest
 from indra_cogex.client.queries import *
-from indra.statements import Inhibition
+from indra.statements import *
 
 from .test_neo4j_client import _get_client
 
@@ -16,6 +16,7 @@ def test_get_pmids_for_mesh():
 
 @pytest.mark.nonpublic
 def test_get_mesh_ids_for_pmid():
+    # Single query
     client = _get_client()
     pmid = ("PUBMED", "27890007")
     mesh_ids = get_mesh_ids_for_pmid(client, pmid)
@@ -24,8 +25,55 @@ def test_get_mesh_ids_for_pmid():
 
 
 @pytest.mark.nonpublic
+def test_get_evidence_obj_for_stmt_hash():
+    # Note: This statement has a ~500 evidences
+    # Single query
+    stmt_hash = '35279776755000170'
+    client = _get_client()
+    ev_objs = get_evidence_obj_for_stmt_hash(client, stmt_hash)
+    assert len(ev_objs) == 529
+    assert isinstance(ev_objs[0], Evidence)
+
+
+@pytest.mark.nonpublic
+def test_get_evidence_obj_for_stmt_hashes():
+    # Note: This statement has ~500 of evidences
+    # Single query
+    stmt_hashes = ['35279776755000170']
+    client = _get_client()
+    ev_dict = get_evidence_obj_for_stmt_hashes(client, stmt_hashes)
+    assert len(ev_dict) == 1
+    assert list(ev_dict.keys())[0] == '35279776755000170'
+    assert len(ev_dict['35279776755000170']) == 529
+    assert isinstance(ev_dict['35279776755000170'][0], Evidence)
+
+
+@pytest.mark.nonpublic
+def test_get_stmts_for_pmid():
+    # Two queries: first evidences, then the statements
+    client = _get_client()
+    pmid = ("PUBMED", "14898026")
+    stmts = get_stmts_for_pmid(client, pmid)
+    assert len(stmts) == 1
+    assert isinstance(stmts[0], Inhibition)
+
+
+@pytest.mark.nonpublic
+def test_get_stmts_for_mesh_id():
+    # Three queries:
+    # 1. pmids with annotation
+    # 2. evidences for publications with pmid in pmids from 1
+    # 3. statements for the evidences in 2
+    client = _get_client()
+    mesh_id = ("MESH", "D000068236")
+    stmts = get_stmts_for_mesh_id(client, mesh_id)
+    assert len(stmts) == 1
+    assert isinstance(stmts[0], Activation)
+
+
+@pytest.mark.nonpublic
 def test_get_stmts_by_hashes():
-    # Note This statement has a 100s of evidences
+    # Note: This statement has a ~500 of evidences
     # Two queries: first statements, then all the evidence for the statements
     stmt_hashes = ['35279776755000170']
     client = _get_client()

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -108,6 +108,16 @@ def test_get_diseases_for_trial():
 
 
 @pytest.mark.nonpublic
+def test_get_pathways_for_gene():
+    client = _get_client()
+    gene = ("HGNC", "16812")
+    pathways = get_pathways_for_gene(client, gene)
+    assert len(pathways)
+    assert isinstance(pathways[0], Node)
+    assert pathways[0].db_ns == 'WIKIPATHWAYS'
+
+
+@pytest.mark.nonpublic
 def test_get_pmids_for_mesh():
     # Single query
     client = _get_client()

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -214,9 +214,9 @@ def test_get_mesh_ids_for_pmid():
 
 @pytest.mark.nonpublic
 def test_get_evidence_obj_for_stmt_hash():
-    # Note: This statement has a ~500 evidences
+    # Note: This statement has 3 evidences
     # Single query
-    stmt_hash = "35279776755000170"
+    stmt_hash = "12198579805553967"
     client = _get_client()
     ev_objs = get_evidence_obj_for_stmt_hash(client, stmt_hash)
     assert len(ev_objs)
@@ -225,15 +225,17 @@ def test_get_evidence_obj_for_stmt_hash():
 
 @pytest.mark.nonpublic
 def test_get_evidence_obj_for_stmt_hashes():
-    # Note: This statement has ~500 of evidences
+    # Note: These statements have 3+5 evidences
     # Single query
-    stmt_hashes = ["35279776755000170"]
+    stmt_hashes = ["12198579805553967", "30651649296901235"]
     client = _get_client()
     ev_dict = get_evidence_obj_for_stmt_hashes(client, stmt_hashes)
     assert len(ev_dict)
-    assert list(ev_dict.keys())[0] == "35279776755000170"
-    assert len(ev_dict["35279776755000170"])
-    assert isinstance(ev_dict["35279776755000170"][0], Evidence)
+    assert set(ev_dict.keys()) == {"12198579805553967", "30651649296901235"}
+    assert len(ev_dict["12198579805553967"])
+    assert len(ev_dict["30651649296901235"])
+    assert isinstance(ev_dict["12198579805553967"][0], Evidence)
+    assert isinstance(ev_dict["30651649296901235"][0], Evidence)
 
 
 @pytest.mark.nonpublic

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -15,6 +15,7 @@ def test_get_genes_in_tissue():
     node0 = genes[0]
     assert isinstance(node0, Node)
     assert node0.db_ns == "HGNC"
+    assert ("HGNC", "9891") in {g.grounding() for g in genes}
 
 
 @pytest.mark.nonpublic
@@ -26,6 +27,7 @@ def test_get_tissues_for_gene():
     node0 = tissues[0]
     assert isinstance(node0, Node)
     assert node0.db_ns in {"UBERON", "CL"}
+    assert ("UBERON", "UBERON:0002349") in {g.grounding() for g in tissues}
 
 
 @pytest.mark.nonpublic
@@ -39,12 +41,13 @@ def test_is_gene_in_tissue():
 @pytest.mark.nonpublic
 def test_get_go_terms_for_gene():
     client = _get_client()
-    gene = ("HGNC", "16813")  # PPP1R27
+    gene = ("HGNC", "2697")  # DBP
     go_terms = get_go_terms_for_gene(client, gene)
     assert go_terms
     node0 = go_terms[0]
     assert isinstance(node0, Node)
     assert node0.db_ns == "GO"
+    assert ("GO", "GO:0000978") in {g.grounding() for g in go_terms}
 
 
 @pytest.mark.nonpublic
@@ -57,6 +60,7 @@ def test_get_genes_for_go_term():
     node0 = genes[0]
     assert isinstance(node0, Node)
     assert node0.db_ns == "HGNC"
+    assert ("HGNC", "2697") in {g.grounding() for g in genes}
 
 
 @pytest.mark.nonpublic
@@ -76,6 +80,7 @@ def test_get_trials_for_drug():
     assert trials
     assert isinstance(trials[0], Node)
     assert trials[0].db_ns == "CLINICALTRIALS"
+    assert ("CLINICALTRIALS", "NCT02703220") in {t.grounding() for t in trials}
 
 
 @pytest.mark.nonpublic
@@ -86,6 +91,7 @@ def test_get_trials_for_disease():
     assert trials
     assert isinstance(trials[0], Node)
     assert trials[0].db_ns == "CLINICALTRIALS"
+    assert ("CLINICALTRIALS", "NCT00011661") in {t.grounding() for t in trials}
 
 
 @pytest.mark.nonpublic
@@ -95,6 +101,7 @@ def test_get_drugs_for_trial():
     drugs = get_drugs_for_trial(client, trial)
     assert drugs
     assert drugs[0].db_ns in ["CHEBI", "MESH"]
+    assert ("MESH", "D014810") in {d.grounding() for d in drugs}
 
 
 @pytest.mark.nonpublic
@@ -105,6 +112,7 @@ def test_get_diseases_for_trial():
     assert diseases
     assert isinstance(diseases[0], Node)
     assert diseases[0].db_ns == "MESH"
+    assert ("MESH", "D012174") in {d.grounding() for d in diseases}
 
 
 @pytest.mark.nonpublic
@@ -115,6 +123,7 @@ def test_get_pathways_for_gene():
     assert pathways
     assert isinstance(pathways[0], Node)
     assert pathways[0].db_ns in {"WIKIPATHWAYS", "REACTOME"}
+    assert ("WIKIPATHWAYS", "WP5037") in {p.grounding() for p in pathways}
 
 
 @pytest.mark.nonpublic
@@ -125,6 +134,7 @@ def test_get_genes_for_pathway():
     assert genes
     assert isinstance(genes[0], Node)
     assert genes[0].db_ns == "HGNC"
+    assert ("HGNC", "16812") in {g.grounding() for g in genes}
 
 
 @pytest.mark.nonpublic
@@ -143,6 +153,7 @@ def test_get_side_effects_for_drug():
     assert side_effects
     assert isinstance(side_effects[0], Node)
     assert side_effects[0].db_ns in ["GO", "UMLS", "MESH", "HP"]
+    assert ("UMLS", "C3267206") in {s.grounding() for s in side_effects}
 
 
 @pytest.mark.nonpublic
@@ -153,6 +164,7 @@ def test_get_drugs_for_side_effect():
     assert drugs
     assert isinstance(drugs[0], Node)
     assert drugs[0].db_ns in ["CHEBI", "MESH"]
+    assert ("CHEBI", "CHEBI:29108") in {d.grounding() for d in drugs}
 
 
 @pytest.mark.nonpublic
@@ -171,6 +183,7 @@ def test_get_ontology_child_terms():
     assert children
     assert isinstance(children[0], Node)
     assert children[0].db_ns == "MESH"
+    assert ("MESH", "D020264") in {c.grounding() for c in children}
 
 
 @pytest.mark.nonpublic
@@ -181,6 +194,7 @@ def test_get_ontology_parent_terms():
     assert parents
     assert isinstance(parents[0], Node)
     assert parents[0].db_ns == "MESH"
+    assert ("MESH", "D007855") in {p.grounding() for p in parents}
 
 
 @pytest.mark.nonpublic
@@ -199,6 +213,7 @@ def test_get_pmids_for_mesh():
     assert pmids
     assert isinstance(pmids[0], Node)
     assert pmids[0].db_ns == "PUBMED"
+    assert ("PUBMED", "14915949") in {p.grounding() for p in pmids}
 
 
 @pytest.mark.nonpublic
@@ -210,6 +225,7 @@ def test_get_mesh_ids_for_pmid():
     assert mesh_ids
     assert isinstance(mesh_ids[0], Node)
     assert mesh_ids[0].db_ns == "MESH"
+    assert ("MESH", "D000544") in {m.grounding() for m in mesh_ids}
 
 
 @pytest.mark.nonpublic

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,8 +1,109 @@
 import pytest
 from indra_cogex.client.queries import *
 from indra.statements import *
+from indra_cogex.representation import Node
 
 from .test_neo4j_client import _get_client
+
+
+@pytest.mark.nonpublic
+def test_get_genes_in_tissue():
+    # Single query
+    client = _get_client()
+    genes = get_genes_in_tissue(client, ("UBERON", "UBERON:0002349"))
+    assert len(genes) == 10213
+    node0 = genes[0]
+    assert isinstance(node0, Node)
+    assert node0.db_ns == 'HGNC'
+
+
+@pytest.mark.nonpublic
+def test_get_tissues_for_gene():
+    # Single query
+    client = _get_client()
+    tissues = get_tissues_for_gene(client, ("HGNC", "9896"))
+    assert len(tissues) == 274
+    node0 = tissues[0]
+    assert isinstance(node0, Node)
+    assert node0.db_ns == 'UBERON'
+
+
+@pytest.mark.nonpublic
+def test_is_gene_in_tissue():
+    client = _get_client()
+    gene = ("HGNC", "9896")  # RBM10
+    tissue = ("UBERON", "UBERON:0035841")  # esophagogastric junction muscularis propria
+    assert is_gene_in_tissue(client, gene, tissue)
+
+
+@pytest.mark.nonpublic
+def test_get_go_terms_for_gene():
+    client = _get_client()
+    gene = ("HGNC", "16813")  # PPP1R27
+    go_terms = get_go_terms_for_gene(client, gene)
+    assert len(go_terms) == 2
+    node0 = go_terms[0]
+    assert isinstance(node0, Node)
+    assert node0.db_ns == 'GO'
+
+
+@pytest.mark.nonpublic
+def test_get_genes_for_go_term():
+    # Single query
+    client = _get_client()
+    go_term = ("GO", "GO:0000978")
+    genes = get_genes_for_go_term(client, go_term)
+    assert len(genes) == 1146
+    node0 = genes[0]
+    assert isinstance(node0, Node)
+    assert node0.db_ns == 'HGNC'
+
+
+@pytest.mark.nonpublic
+def test_is_go_term_for_gene():
+    # Single query
+    client = _get_client()
+    go_term = ("GO", "GO:0000978")
+    gene = ("HGNC", "2697")  # DBP
+    assert is_go_term_for_gene(client, gene, go_term)
+
+
+@pytest.mark.nonpublic
+def test_get_trials_for_drug():
+    client = _get_client()
+    drug = ("CHEBI", "CHEBI:27690")
+    trials = get_trials_for_drug(client, drug)
+    assert len(trials) == 80
+    assert isinstance(trials[0], Node)
+    assert trials[0].db_ns == 'CLINICALTRIALS'
+
+
+@pytest.mark.nonpublic
+def test_get_trials_for_disease():
+    client = _get_client()
+    disease = ("MESH", "D007855")
+    trials = get_trials_for_disease(client, disease)
+    assert len(trials) == 22
+    assert isinstance(trials[0], Node)
+    assert trials[0].db_ns == 'CLINICALTRIALS'
+
+
+@pytest.mark.nonpublic
+def test_get_drugs_for_trial():
+    client = _get_client()
+    trial = ("CLINICALTRIALS", "NCT00000114")
+    drugs = get_drugs_for_trial(client, trial)
+    assert len(drugs) == 2
+
+
+@pytest.mark.nonpublic
+def test_get_diseases_for_trial():
+    client = _get_client()
+    trial = ("CLINICALTRIALS", "NCT00000114")
+    diseases = get_diseases_for_trial(client, trial)
+    assert len(diseases) == 1
+    assert isinstance(diseases[0], Node)
+    assert diseases[0].db_ns == 'MESH'
 
 
 @pytest.mark.nonpublic

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -11,7 +11,7 @@ def test_get_genes_in_tissue():
     # Single query
     client = _get_client()
     genes = get_genes_in_tissue(client, ("UBERON", "UBERON:0002349"))
-    assert len(genes) == 10213
+    assert len(genes)
     node0 = genes[0]
     assert isinstance(node0, Node)
     assert node0.db_ns == 'HGNC'
@@ -22,7 +22,7 @@ def test_get_tissues_for_gene():
     # Single query
     client = _get_client()
     tissues = get_tissues_for_gene(client, ("HGNC", "9896"))
-    assert len(tissues) == 274
+    assert len(tissues)
     node0 = tissues[0]
     assert isinstance(node0, Node)
     assert node0.db_ns == 'UBERON'
@@ -41,7 +41,7 @@ def test_get_go_terms_for_gene():
     client = _get_client()
     gene = ("HGNC", "16813")  # PPP1R27
     go_terms = get_go_terms_for_gene(client, gene)
-    assert len(go_terms) == 2
+    assert len(go_terms)
     node0 = go_terms[0]
     assert isinstance(node0, Node)
     assert node0.db_ns == 'GO'
@@ -53,7 +53,7 @@ def test_get_genes_for_go_term():
     client = _get_client()
     go_term = ("GO", "GO:0000978")
     genes = get_genes_for_go_term(client, go_term)
-    assert len(genes) == 1146
+    assert len(genes)
     node0 = genes[0]
     assert isinstance(node0, Node)
     assert node0.db_ns == 'HGNC'
@@ -73,7 +73,7 @@ def test_get_trials_for_drug():
     client = _get_client()
     drug = ("CHEBI", "CHEBI:27690")
     trials = get_trials_for_drug(client, drug)
-    assert len(trials) == 80
+    assert len(trials)
     assert isinstance(trials[0], Node)
     assert trials[0].db_ns == 'CLINICALTRIALS'
 
@@ -83,7 +83,7 @@ def test_get_trials_for_disease():
     client = _get_client()
     disease = ("MESH", "D007855")
     trials = get_trials_for_disease(client, disease)
-    assert len(trials) == 22
+    assert len(trials)
     assert isinstance(trials[0], Node)
     assert trials[0].db_ns == 'CLINICALTRIALS'
 
@@ -93,7 +93,8 @@ def test_get_drugs_for_trial():
     client = _get_client()
     trial = ("CLINICALTRIALS", "NCT00000114")
     drugs = get_drugs_for_trial(client, trial)
-    assert len(drugs) == 2
+    assert len(drugs)
+    assert drugs[0].db_ns in ['CHEBI', 'MESH']
 
 
 @pytest.mark.nonpublic
@@ -101,7 +102,7 @@ def test_get_diseases_for_trial():
     client = _get_client()
     trial = ("CLINICALTRIALS", "NCT00000114")
     diseases = get_diseases_for_trial(client, trial)
-    assert len(diseases) == 1
+    assert len(diseases)
     assert isinstance(diseases[0], Node)
     assert diseases[0].db_ns == 'MESH'
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -118,6 +118,80 @@ def test_get_pathways_for_gene():
 
 
 @pytest.mark.nonpublic
+def test_get_genes_for_pathway():
+    client = _get_client()
+    pathway = ("WIKIPATHWAYS", "WP5037")
+    genes = get_genes_for_pathway(client, pathway)
+    assert len(genes)
+    assert isinstance(genes[0], Node)
+    assert genes[0].db_ns == 'HGNC'
+
+
+@pytest.mark.nonpublic
+def test_is_gene_in_pathway():
+    client = _get_client()
+    gene = ("HGNC", "16812")
+    pathway = ("WIKIPATHWAYS", "WP5037")
+    assert is_gene_in_pathway(client, gene, pathway)
+
+
+@pytest.mark.nonpublic
+def test_get_side_effects_for_drug():
+    client = _get_client()
+    drug = ("CHEBI", "CHEBI:29108")
+    side_effects = get_side_effects_for_drug(client, drug)
+    assert len(side_effects)
+    assert isinstance(side_effects[0], Node)
+    assert side_effects[0].db_ns in ['GO', 'UMLS', 'MESH', 'HP']
+
+
+@pytest.mark.nonpublic
+def test_get_drugs_for_side_effect():
+    client = _get_client()
+    side_effect = ("UMLS", "C3267206")
+    drugs = get_drugs_for_side_effect(client, side_effect)
+    assert len(drugs)
+    assert isinstance(drugs[0], Node)
+    assert drugs[0].db_ns in ['CHEBI', 'MESH']
+
+
+@pytest.mark.nonpublic
+def test_is_side_effect_for_drug():
+    client = _get_client()
+    drug = ("CHEBI", "CHEBI:29108")
+    side_effect = ("UMLS", "C3267206")
+    assert is_side_effect_for_drug(client, drug, side_effect)
+
+
+@pytest.mark.nonpublic
+def test_get_ontology_child_terms():
+    client = _get_client()
+    term = ("MESH", "D007855")
+    children = get_ontology_child_terms(client, term)
+    assert len(children)
+    assert isinstance(children[0], Node)
+    assert children[0].db_ns == 'MESH'
+
+
+@pytest.mark.nonpublic
+def test_get_ontology_parent_terms():
+    client = _get_client()
+    term = ("MESH", "D020263")
+    parents = get_ontology_parent_terms(client, term)
+    assert len(parents)
+    assert isinstance(parents[0], Node)
+    assert parents[0].db_ns == 'MESH'
+
+
+@pytest.mark.nonpublic
+def test_isa_or_partof():
+    client = _get_client()
+    term = ("MESH", "D020263")
+    parent = ("MESH", "D007855")
+    assert isa_or_partof(client, term, parent)
+
+
+@pytest.mark.nonpublic
 def test_get_pmids_for_mesh():
     # Single query
     client = _get_client()

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -197,7 +197,8 @@ def test_get_pmids_for_mesh():
     client = _get_client()
     pmids = get_pmids_for_mesh(client, ("MESH", "D015002"))
     assert len(pmids)
-    assert pmids[0].startswith("pubmed:")
+    assert isinstance(pmids[0], Node)
+    assert pmids[0].db_ns == "PUBMED"
 
 
 @pytest.mark.nonpublic
@@ -207,7 +208,8 @@ def test_get_mesh_ids_for_pmid():
     pmid = ("PUBMED", "27890007")
     mesh_ids = get_mesh_ids_for_pmid(client, pmid)
     assert len(mesh_ids)
-    assert mesh_ids[0].startswith("mesh:")
+    assert isinstance(mesh_ids[0], Node)
+    assert mesh_ids[0].db_ns == "MESH"
 
 
 @pytest.mark.nonpublic

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -196,7 +196,7 @@ def test_get_pmids_for_mesh():
     # Single query
     client = _get_client()
     pmids = get_pmids_for_mesh(client, ('MESH', 'D015002'))
-    assert len(pmids) == 1591
+    assert len(pmids)
     assert pmids[0].startswith('pubmed:')
 
 
@@ -206,7 +206,7 @@ def test_get_mesh_ids_for_pmid():
     client = _get_client()
     pmid = ("PUBMED", "27890007")
     mesh_ids = get_mesh_ids_for_pmid(client, pmid)
-    assert len(mesh_ids) == 4
+    assert len(mesh_ids)
     assert mesh_ids[0].startswith('mesh:')
 
 
@@ -217,7 +217,7 @@ def test_get_evidence_obj_for_stmt_hash():
     stmt_hash = '35279776755000170'
     client = _get_client()
     ev_objs = get_evidence_obj_for_stmt_hash(client, stmt_hash)
-    assert len(ev_objs) == 529
+    assert len(ev_objs)
     assert isinstance(ev_objs[0], Evidence)
 
 
@@ -228,9 +228,9 @@ def test_get_evidence_obj_for_stmt_hashes():
     stmt_hashes = ['35279776755000170']
     client = _get_client()
     ev_dict = get_evidence_obj_for_stmt_hashes(client, stmt_hashes)
-    assert len(ev_dict) == 1
+    assert len(ev_dict)
     assert list(ev_dict.keys())[0] == '35279776755000170'
-    assert len(ev_dict['35279776755000170']) == 529
+    assert len(ev_dict['35279776755000170'])
     assert isinstance(ev_dict['35279776755000170'][0], Evidence)
 
 
@@ -240,7 +240,7 @@ def test_get_stmts_for_pmid():
     client = _get_client()
     pmid = ("PUBMED", "14898026")
     stmts = get_stmts_for_pmid(client, pmid)
-    assert len(stmts) == 1
+    assert len(stmts)
     assert isinstance(stmts[0], Inhibition)
 
 
@@ -253,7 +253,7 @@ def test_get_stmts_for_mesh_id():
     client = _get_client()
     mesh_id = ("MESH", "D000068236")
     stmts = get_stmts_for_mesh_id(client, mesh_id)
-    assert len(stmts) == 1
+    assert len(stmts)
     assert isinstance(stmts[0], Activation)
 
 
@@ -264,5 +264,5 @@ def test_get_stmts_by_hashes():
     stmt_hashes = ['35279776755000170']
     client = _get_client()
     stmts = get_stmts_for_stmt_hashes(client, stmt_hashes)
-    assert len(stmts) == 1
+    assert len(stmts)
     assert isinstance(stmts[0], Inhibition)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -213,6 +213,15 @@ def test_get_mesh_ids_for_pmid():
 
 
 @pytest.mark.nonpublic
+def test_get_evidence_obj_for_mesh_id():
+    client = _get_client()
+    mesh_id = ("MESH", "D015002")
+    evidence_dict = get_evidence_obj_for_mesh_id(client, mesh_id)
+    assert len(evidence_dict)
+    assert isinstance(list(evidence_dict.values())[0][0], Evidence)
+
+
+@pytest.mark.nonpublic
 def test_get_evidence_obj_for_stmt_hash():
     # Note: This statement has 3 evidences
     # Single query

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -258,13 +258,25 @@ def test_get_stmts_for_pmid():
 
 
 @pytest.mark.nonpublic
-def test_get_stmts_for_mesh_id():
+def test_get_stmts_for_mesh_id_w_children():
     # Two queries:
     # 1. evidences for publications with pmid having mesh annotation
     # 2. statements for the evidences in 2
     client = _get_client()
     mesh_id = ("MESH", "D000068236")
     stmts = get_stmts_for_mesh_id(client, mesh_id)
+    assert len(stmts)
+    assert isinstance(stmts[0], Activation)
+
+
+@pytest.mark.nonpublic
+def test_get_stmts_for_mesh_id_wo_children():
+    # Two queries:
+    # 1. evidences for publications with pmid having mesh annotation
+    # 2. statements for the evidences in 2
+    client = _get_client()
+    mesh_id = ("MESH", "D000068236")
+    stmts = get_stmts_for_mesh_id(client, mesh_id, include_child_terms=False)
     assert len(stmts)
     assert isinstance(stmts[0], Activation)
 


### PR DESCRIPTION
This PR extends the number of mid-level queries available in the `queries` sub-module of the `client` module.

Functions added:
- `get_pmids_for_mesh_id`
- `get_mesh_ids_for_pmid`
- `get_evidence_obj_for_stmt_hash`
- `get_evidence_objects_for_stmt_hashes`
- `get_stmts_for_pmid`
- `get_stmts_for_mesh_id`
- `get_stmts_for_stmt_hashes`