### PR TITLE
Add optional source and target constraints to some queries

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -86,4 +86,4 @@ profile = black
 multi_line_output = 3
 include_trailing_comma = true
 reverse_relative = true
-known_first_party = indra,indra_cogex
+known_local_folder = indra,indra_cogex

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,4 +86,3 @@ profile = black
 multi_line_output = 3
 include_trailing_comma = true
 reverse_relative = true
-known_local_folder = indra,indra_cogex

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,3 +77,13 @@ max-line-length = 120
 [darglint]
 docstring_style = sphinx
 strictness = short
+
+#######################
+# isort Configuration #
+#######################
+[isort]
+profile = black
+multi_line_output = 3
+include_trailing_comma = true
+reverse_relative = true
+known_first_party = indra,indra_cogex

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -315,7 +315,9 @@ class Neo4jClient:
         )
 
     def get_common_sources(
-        self, targets: List[Tuple[str, str]], relation: str,
+        self,
+        targets: List[Tuple[str, str]],
+        relation: str,
         source_type: Optional[str] = None,
         target_type: Optional[str] = None,
     ) -> List[Node]:
@@ -460,7 +462,12 @@ class Neo4jClient:
         sources
             A list of source nodes as INDRA Agents.
         """
-        sources = self.get_sources(target, relation)
+        sources = self.get_sources(
+            target,
+            relation,
+            source_type="BioEntity",
+            target_type="BioEntity",
+        )
         agents = [self.node_to_agent(source) for source in sources]
         return agents
 

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -282,7 +282,13 @@ class Neo4jClient:
         props = {rel.data[prop] for rel in relations if prop in rel.data}
         return props
 
-    def get_sources(self, target: Tuple[str, str], relation: str = None) -> List[Node]:
+    def get_sources(
+        self,
+        target: Tuple[str, str],
+        relation: str = None,
+        source_type: Optional[str] = None,
+        target_type: Optional[str] = None,
+    ) -> List[Node]:
         """Return the nodes related to the target via a given relation type.
 
         Parameters
@@ -291,16 +297,27 @@ class Neo4jClient:
             The target node's ID.
         relation :
             The relation label to constrain to when finding sources.
+        source_type :
+            A constraint on the source type
+        target_type :
+            A constraint on the target type
 
         Returns
         -------
         sources
             A list of source nodes.
         """
-        return self.get_common_sources([target], relation)
+        return self.get_common_sources(
+            [target],
+            relation,
+            source_type=source_type,
+            target_type=target_type,
+        )
 
     def get_common_sources(
-        self, targets: List[Tuple[str, str]], relation: str
+        self, targets: List[Tuple[str, str]], relation: str,
+        source_type: Optional[str] = None,
+        target_type: Optional[str] = None,
     ) -> List[Node]:
         """Return the common source nodes related to all the given targets
         via a given relation type.
@@ -311,6 +328,10 @@ class Neo4jClient:
             The target nodes' IDs.
         relation :
             The relation label to constrain to when finding sources.
+        source_type :
+            A constraint on the source type
+        target_type :
+            A constraint on the target type
 
         Returns
         -------

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -3,8 +3,8 @@ __all__ = ["Neo4jClient"]
 import logging
 from typing import Any, Iterable, List, Mapping, Optional, Set, Tuple, Union
 
+import neo4j
 import neo4j.graph
-import neo4j.work.simple
 from neo4j import GraphDatabase
 
 from indra.config import get_config
@@ -104,7 +104,7 @@ class Neo4jClient:
         tx.close()
         return values
 
-    def get_session(self, renew: Optional[bool] = False) -> neo4j.work.simple.Session:
+    def get_session(self, renew: Optional[bool] = False) -> neo4j.Session:
         """Return an existing session or create one if needed.
 
         Parameters

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -354,7 +354,11 @@ class Neo4jClient:
         return nodes
 
     def get_targets(
-        self, source: Tuple[str, str], relation: Optional[str] = None
+        self,
+        source: Tuple[str, str],
+        relation: Optional[str] = None,
+        source_type: Optional[str] = None,
+        target_type: Optional[str] = None,
     ) -> List[Node]:
         """Return the nodes related to the source via a given relation type.
 
@@ -364,18 +368,29 @@ class Neo4jClient:
             Source namespace and identifier.
         relation :
             The relation label to constrain to when finding targets.
+        source_type :
+            A constraint on the source type
+        target_type :
+            A constraint on the target type
 
         Returns
         -------
         targets
             A list of target nodes.
         """
-        return self.get_common_targets([source], relation)
+        return self.get_common_targets(
+            [source],
+            relation,
+            source_type=source_type,
+            target_type=target_type,
+        )
 
     def get_common_targets(
         self,
         sources: List[Tuple[str, str]],
         relation: str,
+        source_type: Optional[str] = None,
+        target_type: Optional[str] = None,
     ) -> List[Node]:
         """Return the common target nodes related to all the given sources
         via a given relation type.
@@ -386,6 +401,10 @@ class Neo4jClient:
             Source namespace and identifier.
         relation :
             The relation label to constrain to when finding targets.
+        source_type :
+            A constraint on the source type
+        target_type :
+            A constraint on the target type
 
         Returns
         -------

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Iterable, List, Mapping, Optional, Set, Tuple, Union
 
 import neo4j.graph
+import neo4j.work.simple
 from neo4j import GraphDatabase
 
 from indra.config import get_config

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -277,14 +277,18 @@ class Neo4jClient:
             Node namespace and identifier.
         relation :
             Relation type.
+        source_type :
+            Type constraint on the sources for in-edges
+        target_type :
+            Type constraint on te targets for out-edges
 
         Returns
         -------
         rels :
             A list of relations matching the constraints.
         """
-        source_rels = self.get_source_relations(target=node, relation=relation, target_type=target_type)
-        target_rels = self.get_target_relations(source=node, relation=relation, source_type=source_type)
+        source_rels = self.get_source_relations(target=node, relation=relation, source_type=source_type)
+        target_rels = self.get_target_relations(source=node, relation=relation, target_type=target_type)
         all_rels = source_rels + target_rels
         return all_rels
 

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -12,7 +12,6 @@ from indra.ontology.standardize import get_standard_agent
 from indra.statements import Agent
 from indra_cogex.representation import Node, Relation, norm_id, triple_query
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -94,7 +93,6 @@ class Neo4jClient:
             objects (typically neo4j nodes or relations).
         """
         tx = self.get_session().begin_transaction()
-        print(query)
         try:
             res = tx.run(query)
         except Exception as e:

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -238,7 +238,9 @@ class Neo4jClient:
         rels :
             A list of relations matching the constraints.
         """
-        return self.get_relations(source=None, target=target, relation=relation, target_type=target_type)
+        return self.get_relations(
+            source=None, target=target, relation=relation, target_type=target_type
+        )
 
     def get_target_relations(
         self,
@@ -260,7 +262,9 @@ class Neo4jClient:
         rels :
             A list of relations matching the constraints.
         """
-        return self.get_relations(source=source, target=None, relation=relation, source_type=source_type)
+        return self.get_relations(
+            source=source, target=None, relation=relation, source_type=source_type
+        )
 
     def get_all_relations(
         self,
@@ -287,8 +291,12 @@ class Neo4jClient:
         rels :
             A list of relations matching the constraints.
         """
-        source_rels = self.get_source_relations(target=node, relation=relation, source_type=source_type)
-        target_rels = self.get_target_relations(source=node, relation=relation, target_type=target_type)
+        source_rels = self.get_source_relations(
+            target=node, relation=relation, source_type=source_type
+        )
+        target_rels = self.get_target_relations(
+            source=node, relation=relation, target_type=target_type
+        )
         all_rels = source_rels + target_rels
         return all_rels
 

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -20,7 +20,12 @@ def get_genes_in_tissue(client: Neo4jClient, tissue: Tuple[str, str]) -> Iterabl
     :
         The genes expressed in the given tissue.
     """
-    return client.get_sources(tissue, relation="expressed_in")
+    return client.get_sources(
+        tissue,
+        relation="expressed_in",
+        source_type="BioEntity",
+        target_type="BioEntity",
+    )
 
 
 def get_tissues_for_gene(client: Neo4jClient, gene: Tuple[str, str]) -> Iterable[Node]:
@@ -38,7 +43,12 @@ def get_tissues_for_gene(client: Neo4jClient, gene: Tuple[str, str]) -> Iterable
     :
         The tissues the gene is expressed in.
     """
-    return client.get_targets(gene, relation="expressed_in")
+    return client.get_targets(
+        gene,
+        relation="expressed_in",
+        source_type="BioEntity",
+        target_type="BioEntity",
+    )
 
 
 def is_gene_in_tissue(
@@ -60,7 +70,13 @@ def is_gene_in_tissue(
     :
         True if the gene is expressed in the given tissue.
     """
-    return client.has_relation(gene, tissue, relation="expressed_in")
+    return client.has_relation(
+        gene,
+        tissue,
+        relation="expressed_in",
+        source_type="BioEntity",
+        target_type="BioEntity",
+    )
 
 
 # GO
@@ -89,7 +105,10 @@ def get_go_terms_for_gene(
     go_terms = {gtn.grounding(): gtn for gtn in go_term_nodes}
     for go_term_node in go_term_nodes:
         go_child_terms = client.get_successors(
-            go_term_node.grounding(), relations=["isa"]
+            go_term_node.grounding(),
+            relations=["isa"],
+            source_type="BioEntity",
+            target_type="BioEntity",
         )
         for term in go_child_terms:
             go_terms[term.grounding()] = term
@@ -149,7 +168,13 @@ def is_go_term_for_gene(
     :
         True if the given GO term is associated with the given gene.
     """
-    return client.has_relation(gene, go_term, relation="associated_with")
+    return client.has_relation(
+        gene,
+        go_term,
+        relation="associated_with",
+        source_type="BioEntity",
+        target_type="BioEntity",
+    )
 
 
 # Trials
@@ -170,7 +195,12 @@ def get_trials_for_drug(client: Neo4jClient, drug: Tuple[str, str]) -> Iterable[
     :
         The trials for the given drug.
     """
-    return client.get_targets(drug, relation="tested_in")
+    return client.get_targets(
+        drug,
+        relation="tested_in",
+        source_type="BioEntity",
+        target_type="ClinicalTrial",
+    )
 
 
 def get_trials_for_disease(
@@ -190,7 +220,12 @@ def get_trials_for_disease(
     :
         The trials for the given disease.
     """
-    return client.get_targets(disease, relation="has_trial")
+    return client.get_targets(
+        disease,
+        relation="has_trial",
+        source_type="BioEntity",
+        target_type="ClinicalTrial",
+    )
 
 
 def get_drugs_for_trial(client: Neo4jClient, trial: Tuple[str, str]) -> Iterable[Node]:
@@ -208,7 +243,12 @@ def get_drugs_for_trial(client: Neo4jClient, trial: Tuple[str, str]) -> Iterable
     :
         The drugs for the given trial.
     """
-    return client.get_sources(trial, relation="tested_in")
+    return client.get_sources(
+        trial,
+        relation="tested_in",
+        source_type="BioEntity",
+        target_type="ClinicalTrial",
+    )
 
 
 def get_diseases_for_trial(
@@ -228,7 +268,12 @@ def get_diseases_for_trial(
     :
         The diseases for the given trial.
     """
-    return client.get_sources(trial, relation="has_trial")
+    return client.get_sources(
+        trial,
+        relation="has_trial",
+        source_type="BioEntity",
+        target_type="ClinicalTrial",
+    )
 
 
 # Pathways
@@ -249,7 +294,12 @@ def get_pathways_for_gene(client: Neo4jClient, gene: Tuple[str, str]) -> Iterabl
     :
         The pathways for the given gene.
     """
-    return client.get_targets(gene, relation="haspart")
+    return client.get_targets(
+        gene,
+        relation="haspart",
+        source_type="BioEntity",
+        target_type="BioEntity",
+    )
 
 
 def get_genes_for_pathway(
@@ -296,7 +346,13 @@ def is_gene_in_pathway(
     :
         True if the gene is in the given pathway.
     """
-    return client.has_relation(gene, pathway, relation="haspart")
+    return client.has_relation(
+        gene,
+        pathway,
+        relation="haspart",
+        source_type="BioEntity",
+        target_type="BioEntity",
+    )
 
 
 # Side effects
@@ -319,7 +375,12 @@ def get_side_effects_for_drug(
     :
         The side effects for the given drug.
     """
-    return client.get_targets(drug, relation="has_side_effect")
+    return client.get_targets(
+        drug,
+        relation="has_side_effect",
+        source_type="BioEntity",
+        target_type="BioEntity",
+    )
 
 
 def get_drugs_for_side_effect(
@@ -339,7 +400,12 @@ def get_drugs_for_side_effect(
     :
         The drugs for the given side effect.
     """
-    return client.get_sources(side_effect, relation="has_side_effect")
+    return client.get_sources(
+        side_effect,
+        relation="has_side_effect",
+        source_type="BioEntity",
+        target_type="BioEntity",
+    )
 
 
 def is_side_effect_for_drug(
@@ -361,7 +427,13 @@ def is_side_effect_for_drug(
     :
         True if the given side effect is associated with the given drug.
     """
-    return client.has_relation(drug, side_effect, relation="has_side_effect")
+    return client.has_relation(
+        drug,
+        side_effect,
+        relation="has_side_effect",
+        source_type="BioEntity",
+        target_type="BioEntity",
+    )
 
 
 # Ontology

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -269,7 +269,12 @@ def get_genes_for_pathway(
     :
         The genes for the given pathway.
     """
-    return client.get_targets(pathway, relation="haspart", source_type="BioEntity", target_type="BioEntity")
+    return client.get_targets(
+        pathway,
+        relation="haspart",
+        source_type="BioEntity",
+        target_type="BioEntity",
+    )
 
 
 def is_gene_in_pathway(

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -269,7 +269,7 @@ def get_genes_for_pathway(
     :
         The genes for the given pathway.
     """
-    return client.get_targets(pathway, relation="haspart")
+    return client.get_targets(pathway, relation="haspart", source_type="BioEntity", target_type="BioEntity")
 
 
 def is_gene_in_pathway(

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -107,6 +107,9 @@ def get_genes_for_go_term(
         The Neo4j client.
     go_term :
         The GO term to query.
+    include_indirect :
+        Should ontological children of the given GO term
+        be queried as well? Defaults to False.
 
     Returns
     -------
@@ -116,7 +119,12 @@ def get_genes_for_go_term(
     go_children = get_ontology_child_terms(client, go_term) if include_indirect else []
     gene_nodes = {}
     for term in [go_term] + go_children:
-        genes = client.get_sources(term, relation="associated_with")
+        genes = client.get_sources(
+            term,
+            relation="associated_with",
+            source_type="BioEntity",
+            target_type="BioEntity",
+        )
         for gene in genes:
             gene_nodes[gene.grounding()] = gene
     return list(gene_nodes.values())

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -1,4 +1,5 @@
 from typing import Iterable, Tuple
+
 from .neo4j_client import Neo4jClient
 from ..representation import Node
 

--- a/src/indra_cogex/client/subnetwork.py
+++ b/src/indra_cogex/client/subnetwork.py
@@ -1,9 +1,9 @@
 from typing import List, Tuple
 
+from indra.statements import Statement
 from .neo4j_client import Neo4jClient
 from .queries import get_expressed_genes_in_tissue
 from ..representation import Node, indra_stmts_from_relations, norm_id
-from indra.statements import Statement
 
 
 def indra_subnetwork(

--- a/src/indra_cogex/client/subnetwork.py
+++ b/src/indra_cogex/client/subnetwork.py
@@ -23,6 +23,8 @@ def indra_subnetwork(
         The subnetwork induced by the given nodes.
     """
     nodes_str = ", ".join(["'%s'" % norm_id(*node) for node in nodes])
+    # TODO add BioEntity constraint to source and target,
+    #  since all INDRA-like entities should be BioEntities?
     query = """MATCH p=(n1)-[r:indra_rel]->(n2)
             WHERE n1.id IN [%s]
             AND n2.id IN [%s]

--- a/src/indra_cogex/client/subnetwork.py
+++ b/src/indra_cogex/client/subnetwork.py
@@ -1,10 +1,9 @@
 from typing import List, Tuple
 
-from indra.statements import Statement
-
 from .neo4j_client import Neo4jClient
 from .queries import get_expressed_genes_in_tissue
 from ..representation import Node, indra_stmts_from_relations, norm_id
+from indra.statements import Statement
 
 
 def indra_subnetwork(

--- a/src/indra_cogex/client/subnetwork.py
+++ b/src/indra_cogex/client/subnetwork.py
@@ -1,8 +1,10 @@
 from typing import List, Tuple
+
 from indra.statements import Statement
-from .queries import get_expressed_genes_in_tissue
+
 from .neo4j_client import Neo4jClient
-from ..representation import norm_id, Node, indra_stmts_from_relations
+from .queries import get_expressed_genes_in_tissue
+from ..representation import Node, indra_stmts_from_relations, norm_id
 
 
 def indra_subnetwork(
@@ -23,9 +25,7 @@ def indra_subnetwork(
         The subnetwork induced by the given nodes.
     """
     nodes_str = ", ".join(["'%s'" % norm_id(*node) for node in nodes])
-    # TODO add BioEntity constraint to source and target,
-    #  since all INDRA-like entities should be BioEntities?
-    query = """MATCH p=(n1)-[r:indra_rel]->(n2)
+    query = """MATCH p=(n1:BioEntity)-[r:indra_rel]->(n2:BioEntity)
             WHERE n1.id IN [%s]
             AND n2.id IN [%s]
             AND n1.id <> n2.id


### PR DESCRIPTION
This should improve the performance of `get_genes_for_go_term()`

- [x] #53
- [x] Add additional places for constraints
- [ ] Testing (borrow tests from #50?)

This PR also adds a very tiny configuration for `isort` to keep import order consistent (in case pycharm reorganizes them, it's a pain to undo without isort)