### PR TITLE
Add indexing client and module

### DIFF
--- a/build_extra_indexes.sh
+++ b/build_extra_indexes.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+python -m indra_cogex.indexing --index_evidence_nodes

--- a/build_extra_indexes.sh
+++ b/build_extra_indexes.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-python -m indra_cogex.indexing --index_evidence_nodes
+python -m indra_cogex.indexing --all --exist-ok

--- a/deployment.md
+++ b/deployment.md
@@ -36,6 +36,9 @@ the service with
 sudo neo4j start
 ```
 
+Once the service has started and accepts connections, indexes can be built 
+by running `build_extra_indexes.sh`.
+
 In terms of authentication, one simple way to set up a custom password
 initially is to connect to the neo4j browser and do it via the web UI.
 

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -786,7 +786,8 @@ class Neo4jClient:
     ):
         """Create a single property node index.
 
-        Following example here: https://neo4j.com/docs/cypher-manual/4.1/administration/indexes-for-search-performance/#administration-indexes-create-a-single-property-index-only-if-it-does-not-already-exist
+        Reference:
+        https://neo4j.com/docs/cypher-manual/4.4/indexes-for-search-performance/#administration-indexes-create-a-single-property-b-tree-index-only-if-it-does-not-already-exist
 
         Parameters
         ----------

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -782,7 +782,7 @@ class Neo4jClient:
         return self.create_tx(query)
 
     def create_single_property_node_index(
-        self, index_name: str, label: str, property_name: str, raise_err: bool = False
+        self, index_name: str, label: str, property_name: str, exist_ok: bool = True
     ):
         """Create a single property node index.
 
@@ -796,15 +796,15 @@ class Neo4jClient:
             The label of the node.
         property_name :
             The property name to index.
-        raise_err :
-            Whether to raise an error if the index already exists.
+        exist_ok :
+            If False, raise an error if the index already exists. Default: True.
         """
         logger.info(
             f"Creating index '{index_name}' for label '{label}' on property "
             f"'{property_name}'. Index is created in background and may not "
             f"be available immediately."
         )
-        if_not = " IF NOT EXISTS" if not raise_err else ""
+        if_not = " IF NOT EXISTS" if exist_ok else ""
         create_query = (
             f"CREATE INDEX {index_name}{if_not} FOR (n:{label}) ON (n.{property_name})"
         )

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -781,6 +781,36 @@ class Neo4jClient:
         )
         return self.create_tx(query)
 
+    def create_single_property_node_index(
+        self, index_name: str, label: str, property_name: str, raise_err: bool = False
+    ):
+        """Create a single property node index.
+
+        Following example here: https://neo4j.com/docs/cypher-manual/4.1/administration/indexes-for-search-performance/#administration-indexes-create-a-single-property-index-only-if-it-does-not-already-exist
+
+        Parameters
+        ----------
+        index_name :
+            The name of the index.
+        label :
+            The label of the node.
+        property_name :
+            The property name to index.
+        raise_err :
+            Whether to raise an error if the index already exists.
+        """
+        logger.info(
+            f"Creating index '{index_name}' for label '{label}' on property "
+            f"'{property_name}'. Index is created in background and may not "
+            f"be available immediately."
+        )
+        if_not = " IF NOT EXISTS" if not raise_err else ""
+        create_query = (
+            f"CREATE INDEX {index_name}{if_not} FOR (n:{label}) ON (n.{property_name})"
+        )
+
+        self.create_tx(create_query)
+
 
 def process_identifier(identifier: str) -> Tuple[str, str]:
     """Process a neo4j-internal identifier string into an INDRA namespace and ID.

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -812,6 +812,36 @@ class Neo4jClient:
 
         self.create_tx(create_query)
 
+    def create_single_property_relationship_index(
+        self, index_name: str, rel_type: str, property_name: str
+    ):
+        """Create a single property relationship index.
+
+        NOTE: Relationship indexes can only be created once, and there is no
+        IF NOT EXISTS option to silently ignore if the index already exists.
+
+        Reference:
+        https://neo4j.com/docs/cypher-manual/4.4/indexes-for-search-performance/#administration-indexes-create-a-single-property-b-tree-index-for-relationships
+
+        Parameters
+        ----------
+        index_name :
+            The name of the index.
+        rel_type :
+            The relationship type to index a property on
+        property_name :
+            The property name to index.
+        """
+        logger.info(
+            f"Creating index '{index_name}' for relationship type '{rel_type}' on "
+            f"property '{property_name}'. Index is created in background and may not "
+            f"be available immediately."
+        )
+        create_query = (
+            f"CREATE INDEX {index_name} FOR ()-[r:{rel_type}]-() ON (r.{property_name})"
+        )
+        self.create_tx(create_query)
+
 
 def process_identifier(identifier: str) -> Tuple[str, str]:
     """Process a neo4j-internal identifier string into an INDRA namespace and ID.

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -782,7 +782,7 @@ class Neo4jClient:
         return self.create_tx(query)
 
     def create_single_property_node_index(
-        self, index_name: str, label: str, property_name: str, exist_ok: bool = True
+        self, index_name: str, label: str, property_name: str, exist_ok: bool = False
     ):
         """Create a single property node index.
 
@@ -797,7 +797,8 @@ class Neo4jClient:
         property_name :
             The property name to index.
         exist_ok :
-            If False, raise an error if the index already exists. Default: True.
+            If True, ignore the indexes that already exist. If False,
+            raise error if index already exists. Default: False.
         """
         logger.info(
             f"Creating index '{index_name}' for label '{label}' on property "

--- a/src/indra_cogex/indexing/__init__.py
+++ b/src/indra_cogex/indexing/__init__.py
@@ -5,13 +5,13 @@
 from ..client.neo4j_client import Neo4jClient
 
 
-def index_evidence_on_stmt_hash(exist_ok: bool = True):
+def index_evidence_on_stmt_hash(exist_ok: bool = False):
     """Index all Evidence nodes on the statement hash
 
     Parameters
     ----------
     exist_ok :
-        If True, raise an exception if the index already exists.
+        If False, raise an exception if the index already exists. Default: False.
     """
     client = Neo4jClient()
     client.create_single_property_node_index(

--- a/src/indra_cogex/indexing/__init__.py
+++ b/src/indra_cogex/indexing/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+"""A collection of functions for indexing on the database."""
+
+from ..client.neo4j_client import Neo4jClient
+
+
+def index_evidence_on_stmt_hash(exist_ok: bool = True):
+    """Index all Evidence nodes on the statement hash
+
+    Parameters
+    ----------
+    exist_ok :
+        If True, raise an exception if the index already exists.
+    """
+    client = Neo4jClient()
+    client.create_single_property_node_index(
+        "ev_hash", "Evidence", "stmt_hash", exist_ok=exist_ok
+    )

--- a/src/indra_cogex/indexing/__init__.py
+++ b/src/indra_cogex/indexing/__init__.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 
 """A collection of functions for indexing on the database."""
+from indra_cogex.client.neo4j_client import Neo4jClient
 
-from ..client.neo4j_client import Neo4jClient
 
-
-def index_evidence_on_stmt_hash(exist_ok: bool = False):
+def index_evidence_on_stmt_hash(client: Neo4jClient, exist_ok: bool = False):
     """Index all Evidence nodes on the statement hash
 
     Parameters
     ----------
+    client :
+        Neo4jClient instance to the graph database to be indexed
     exist_ok :
         If False, raise an exception if the index already exists. Default: False.
     """
-    client = Neo4jClient()
     client.create_single_property_node_index(
         index_name="ev_hash",
         label="Evidence",
@@ -22,9 +22,14 @@ def index_evidence_on_stmt_hash(exist_ok: bool = False):
     )
 
 
-def index_indra_rel_on_stmt_hash():
-    """Index all indra_rel relationships on stmt_hash"""
-    client = Neo4jClient()
+def index_indra_rel_on_stmt_hash(client: Neo4jClient):
+    """Index all indra_rel relationships on stmt_hash
+
+    Parameters
+    ----------
+    client :
+        Neo4jClient instance to the graph database to be indexed
+    """
     client.create_single_property_node_index(
         index_name="indra_rel_hash", label="indra_rel", property_name="stmt_hash"
     )

--- a/src/indra_cogex/indexing/__init__.py
+++ b/src/indra_cogex/indexing/__init__.py
@@ -15,7 +15,10 @@ def index_evidence_on_stmt_hash(exist_ok: bool = False):
     """
     client = Neo4jClient()
     client.create_single_property_node_index(
-        "ev_hash", "Evidence", "stmt_hash", exist_ok=exist_ok
+        index_name="ev_hash",
+        label="Evidence",
+        property_name="stmt_hash",
+        exist_ok=exist_ok,
     )
 
 

--- a/src/indra_cogex/indexing/__init__.py
+++ b/src/indra_cogex/indexing/__init__.py
@@ -17,3 +17,11 @@ def index_evidence_on_stmt_hash(exist_ok: bool = False):
     client.create_single_property_node_index(
         "ev_hash", "Evidence", "stmt_hash", exist_ok=exist_ok
     )
+
+
+def index_indra_rel_on_stmt_hash():
+    """Index all indra_rel relationships on stmt_hash"""
+    client = Neo4jClient()
+    client.create_single_property_node_index(
+        index_name="indra_rel_hash", label="indra_rel", property_name="stmt_hash"
+    )

--- a/src/indra_cogex/indexing/__main__.py
+++ b/src/indra_cogex/indexing/__main__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+"""Run the database indexing using ``python -m indra_cogex.indexing``."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/indra_cogex/indexing/cli.py
+++ b/src/indra_cogex/indexing/cli.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Run the database indexing."""
+from typing import Optional, Tuple
 
 import click
 
@@ -26,14 +27,25 @@ def main(
     index_evidence_nodes: bool = False,
     index_indra_relations: bool = False,
     exist_ok: bool = False,
+    url: Optional[str] = None,
+    auth: Optional[Tuple[str, str]] = None,
 ):
     """Build indexes on the database."""
+    client = _get_client(url, auth)
     if index_evidence_nodes:
         from . import index_evidence_on_stmt_hash
         click.secho("Indexing Evidence nodes on the stmt_hash property.", fg="green")
-        index_evidence_on_stmt_hash(exist_ok=exist_ok)
+        index_evidence_on_stmt_hash(client, exist_ok=exist_ok)
     if index_indra_relations:
         from . import index_indra_rel_on_stmt_hash
         click.secho("Indexing INDRA relations on the stmt_hash property.", fg="green")
-        index_indra_rel_on_stmt_hash()
+        index_indra_rel_on_stmt_hash(client)
     click.secho("Started all requested indexing.", fg="green")
+
+
+def _get_client(
+    url: Optional[str] = None, auth: Optional[Tuple[str, str]] = None
+) -> "Neo4jClient":
+    from ..client.neo4j_client import Neo4jClient
+
+    return Neo4jClient(url, auth)

--- a/src/indra_cogex/indexing/cli.py
+++ b/src/indra_cogex/indexing/cli.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 import click
 
 
-@click.command(name="Build extra indexes")
+@click.command(name="extra_indexing")
 @click.option(
     "--all",
     "all_",

--- a/src/indra_cogex/indexing/cli.py
+++ b/src/indra_cogex/indexing/cli.py
@@ -4,8 +4,6 @@
 
 import click
 
-from . import index_evidence_on_stmt_hash
-
 
 @click.command(name="Build extra indexes")
 @click.option(
@@ -22,5 +20,7 @@ from . import index_evidence_on_stmt_hash
 def main(index_evidence_nodes: bool = False, exist_ok: bool = False):
     """Build indexes on the database."""
     if index_evidence_nodes:
+        from . import index_evidence_on_stmt_hash
+        click.secho("Indexing Evidence nodes on the stmt_hash property.", fg="green")
         index_evidence_on_stmt_hash(exist_ok=exist_ok)
     click.secho("Started all requested indexing.", fg="green")

--- a/src/indra_cogex/indexing/cli.py
+++ b/src/indra_cogex/indexing/cli.py
@@ -13,7 +13,13 @@ from . import index_evidence_on_stmt_hash
     is_flag=True,
     help="Index the Evidence nodes on the stmt_hash property."
 )
-def main(index_evidence_nodes: bool = False, exist_ok: bool = True):
+@click.option(
+    "--exist-ok",
+    is_flag=True,
+    help="If set, skip already set indices silently, otherwise an exception "
+         "is raised if attempting to set an index that already exists."
+)
+def main(index_evidence_nodes: bool = False, exist_ok: bool = False):
     """Build indexes on the database."""
     if index_evidence_nodes:
         index_evidence_on_stmt_hash(exist_ok=exist_ok)

--- a/src/indra_cogex/indexing/cli.py
+++ b/src/indra_cogex/indexing/cli.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+"""Run the database indexing."""
+
+import click
+
+from . import index_evidence_on_stmt_hash
+
+
+@click.command(name="Build extra indexes")
+@click.option(
+    "--index_evidence_nodes",
+    is_flag=True,
+    help="Index the Evidence nodes on the stmt_hash property."
+)
+def main(index_evidence_nodes: bool = False, exist_ok: bool = True):
+    """Build indexes on the database."""
+    if index_evidence_nodes:
+        index_evidence_on_stmt_hash(exist_ok=exist_ok)
+    click.secho("Started all requested indexing.", fg="green")

--- a/src/indra_cogex/indexing/cli.py
+++ b/src/indra_cogex/indexing/cli.py
@@ -9,7 +9,7 @@ from . import index_evidence_on_stmt_hash
 
 @click.command(name="Build extra indexes")
 @click.option(
-    "--index_evidence_nodes",
+    "--index-evidence-nodes",
     is_flag=True,
     help="Index the Evidence nodes on the stmt_hash property."
 )

--- a/src/indra_cogex/indexing/cli.py
+++ b/src/indra_cogex/indexing/cli.py
@@ -8,6 +8,12 @@ import click
 
 @click.command(name="Build extra indexes")
 @click.option(
+    "--all",
+    "all_",
+    is_flag=True,
+    help="Build all indexes",
+)
+@click.option(
     "--index-evidence-nodes",
     is_flag=True,
     help="Index the Evidence nodes on the stmt_hash property.",
@@ -24,6 +30,7 @@ import click
     "is raised if attempting to set an index that already exists.",
 )
 def main(
+    all_: bool = False,
     index_evidence_nodes: bool = False,
     index_indra_relations: bool = False,
     exist_ok: bool = False,
@@ -32,11 +39,11 @@ def main(
 ):
     """Build indexes on the database."""
     client = _get_client(url, auth)
-    if index_evidence_nodes:
+    if all_ or index_evidence_nodes:
         from . import index_evidence_on_stmt_hash
         click.secho("Indexing Evidence nodes on the stmt_hash property.", fg="green")
         index_evidence_on_stmt_hash(client, exist_ok=exist_ok)
-    if index_indra_relations:
+    if all_ or index_indra_relations:
         from . import index_indra_rel_on_stmt_hash
         click.secho("Indexing INDRA relations on the stmt_hash property.", fg="green")
         index_indra_rel_on_stmt_hash(client)

--- a/src/indra_cogex/indexing/cli.py
+++ b/src/indra_cogex/indexing/cli.py
@@ -9,18 +9,31 @@ import click
 @click.option(
     "--index-evidence-nodes",
     is_flag=True,
-    help="Index the Evidence nodes on the stmt_hash property."
+    help="Index the Evidence nodes on the stmt_hash property.",
+)
+@click.option(
+    "--index-indra-relations",
+    is_flag=True,
+    help="Index the INDRA relations on the stmt_hash property.",
 )
 @click.option(
     "--exist-ok",
     is_flag=True,
     help="If set, skip already set indices silently, otherwise an exception "
-         "is raised if attempting to set an index that already exists."
+    "is raised if attempting to set an index that already exists.",
 )
-def main(index_evidence_nodes: bool = False, exist_ok: bool = False):
+def main(
+    index_evidence_nodes: bool = False,
+    index_indra_relations: bool = False,
+    exist_ok: bool = False,
+):
     """Build indexes on the database."""
     if index_evidence_nodes:
         from . import index_evidence_on_stmt_hash
         click.secho("Indexing Evidence nodes on the stmt_hash property.", fg="green")
         index_evidence_on_stmt_hash(exist_ok=exist_ok)
+    if index_indra_relations:
+        from . import index_indra_rel_on_stmt_hash
+        click.secho("Indexing INDRA relations on the stmt_hash property.", fg="green")
+        index_indra_rel_on_stmt_hash()
     click.secho("Started all requested indexing.", fg="green")

--- a/src/indra_cogex/sources/cbioportal/__init__.py
+++ b/src/indra_cogex/sources/cbioportal/__init__.py
@@ -109,7 +109,7 @@ class CcleCnaProcessor(Processor):
                         target_ns="CCLE",
                         target_id=cell_line,
                         rel_type="copy_number_altered_in",
-                        data={"CNA": row[cell_line], "source": "ccle"},
+                        data={"CNA:int": row[cell_line], "source": "ccle"},
                     )
 
 

--- a/src/indra_cogex/sources/chembl/__init__.py
+++ b/src/indra_cogex/sources/chembl/__init__.py
@@ -80,9 +80,9 @@ class ChemblIndicationsProcessor(Processor):
                 indication.db_ns,
                 indication.db_id,
                 "has_indication",
-                dict(
-                    source=self.name,
-                    max_phase=max_phase,
-                    version=self.version,
-                ),
+                {
+                    "source": self.name,
+                    "max_phase:int": max_phase,
+                    "version": self.version,
+                },
             )

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -315,8 +315,8 @@ class EvidenceProcessor(Processor):
                             raw_stmt_id,
                             ["Evidence"],
                             {
-                                "evidence": json.dumps(evidence),
-                                "stmt_hash": stmt_hash,
+                                "evidence:string": json.dumps(evidence),
+                                "stmt_hash:long": stmt_hash,
                             },
                         )
                     )

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -89,7 +89,11 @@ class PubmedProcessor(Processor):
                             "MESH",
                             mesh_id,
                             "annotated_with",
-                            {"is_major_topic": True if major_topic == "1" else False},
+                            {
+                                "is_major_topic:boolean": True
+                                if major_topic == "1"
+                                else False
+                            },
                         )
                     )
                 yield relations_batch

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -89,7 +89,11 @@ class PubmedProcessor(Processor):
                             "MESH",
                             mesh_id,
                             "annotated_with",
-                            {"is_major_topic:boolean": major_topic == "1"},
+                            {
+                                "is_major_topic:boolean": "true"
+                                if major_topic == "1"
+                                else "false"
+                            },
                         )
                     )
                 yield relations_batch

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -89,11 +89,7 @@ class PubmedProcessor(Processor):
                             "MESH",
                             mesh_id,
                             "annotated_with",
-                            {
-                                "is_major_topic:boolean": True
-                                if major_topic == "1"
-                                else False
-                            },
+                            {"is_major_topic:boolean": major_topic == "1"},
                         )
                     )
                 yield relations_batch

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -65,7 +65,7 @@ class PubmedProcessor(Processor):
                     "pii": get_val(pii),
                     "url": get_val(url),
                     "manuscript_id": get_val(manuscript_id),
-                    "year": year,
+                    "year:int": year,
                 }
                 yield Node("PUBMED", pmid, labels=[pmid_node_type], data=data)
 


### PR DESCRIPTION
This PR does 3 updates:

1. Add node and relationship indexing methods to the neo4j client that creates a single-property b-tree index for [nodes](https://neo4j.com/docs/cypher-manual/4.4/indexes-for-search-performance/#administration-indexes-create-a-single-property-b-tree-index-for-nodes) or [relationships](https://neo4j.com/docs/cypher-manual/4.4/indexes-for-search-performance/#administration-indexes-create-a-single-property-b-tree-index-for-relationships), respectively. _Note that relationship indexing is only available in neo4j 4.3+ (see [release notes](https://neo4j.com/release-notes/database/neo4j-4-3-0/) and [blog post](https://medium.com/neo4j/neo4j-4-3-blog-series-relationship-indexes-14d2b656abd2))_
2. Add CLI commands with `click` for building indexes.
3. Update field types for some node and relationship properties from `string` to e.g. `int` or `boolean`. This will allow a cypher query to filter on properties according to their field type, e.g.

```
MATCH (k:Publication)-[:annotated_with]->(:BioEntity)
WHERE k.year > 2010
RETURN DISTINCT k
```