### PR TITLE
Persistant sessions

### DIFF
--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -53,6 +53,9 @@ class Neo4jClient:
                 logger.info("Using configured credentials for INDRA neo4j connection")
             else:
                 logger.info("INDRA_NEO4J_USER and INDRA_NEO4J_PASSWORD not configured")
+        # Set max_connection_lifetime to something smaller than the timeouts
+        # on the server or on the way to the server. See
+        # https://github.com/neo4j/neo4j-python-driver/issues/316#issuecomment-564020680
         self.driver = GraphDatabase.driver(url, auth=auth,
                                            max_connection_lifetime=3*60,)
 

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -53,7 +53,8 @@ class Neo4jClient:
                 logger.info("Using configured credentials for INDRA neo4j connection")
             else:
                 logger.info("INDRA_NEO4J_USER and INDRA_NEO4J_PASSWORD not configured")
-        self.driver = GraphDatabase.driver(url, auth=auth)
+        self.driver = GraphDatabase.driver(url, auth=auth,
+                                           max_connection_lifetime=3*60,)
 
     def create_tx(
         self,
@@ -71,7 +72,6 @@ class Neo4jClient:
         """
         tx = self.get_session().begin_transaction()
         try:
-            # logger.info(query)
             tx.run(query, parameters=query_params)
             tx.commit()
         except Exception as e:


### PR DESCRIPTION
This PR sets the `max_connection_lifetime` when initializing the Neo4j driver which should keep connections from erroring.

The time set should be shorter than any timeouts set server side in e.g. the ELB or Nginx on the EC2 instance.

To quote the issue that brought up the specific problem encountered:

> The max_connection_lifetime setting was introduced so as to allow the driver to gracefully pre-empt the AWS shutdowns, and as such should be set to slightly less than the AWS idle time (e.g. 55 seconds vs the AWS default of 60 seconds). This will ensure that connections obtained from the pool are not so old as to expire by the AWS mechanism. Connections shutdown gracefully by the driver should not become defunct; you should therefore not see this error.