### PR TITLE
Add new decorator `autoclient`

### DIFF
--- a/src/indra_cogex/client/enrichment/continuous.py
+++ b/src/indra_cogex/client/enrichment/continuous.py
@@ -26,7 +26,7 @@ from indra_cogex.client.enrichment.utils import (
     get_reactome,
     get_wikipathways,
 )
-from indra_cogex.client.neo4j_client import Neo4jClient
+from indra_cogex.client.neo4j_client import Neo4jClient, autoclient
 
 __all__ = [
     "get_rat_scores",
@@ -110,10 +110,12 @@ def get_rat_scores(
     return df[score_column_name].to_dict()
 
 
+@autoclient
 def wikipathways_gsea(
-    client: Neo4jClient,
     scores: Dict[str, float],
     directory: Union[None, Path, str] = None,
+    *,
+    client: Neo4jClient,
     **kwargs,
 ) -> pd.DataFrame:
     """Run GSEA with WikiPathways gene sets.
@@ -137,17 +139,19 @@ def wikipathways_gsea(
         A pandas dataframe with the GSEA results
     """
     return gsea(
-        gene_sets=get_wikipathways(client),
+        gene_sets=get_wikipathways(client=client),
         scores=scores,
         directory=directory,
         **kwargs,
     )
 
 
+@autoclient
 def reactome_gsea(
-    client: Neo4jClient,
     scores: Dict[str, float],
     directory: Union[None, Path, str] = None,
+    *,
+    client: Neo4jClient,
     **kwargs,
 ) -> pd.DataFrame:
     """Run GSEA with Reactome gene sets.
@@ -171,17 +175,19 @@ def reactome_gsea(
         A pandas dataframe with the GSEA results
     """
     return gsea(
-        gene_sets=get_reactome(client),
+        gene_sets=get_reactome(client=client),
         scores=scores,
         directory=directory,
         **kwargs,
     )
 
 
+@autoclient
 def go_gsea(
-    client: Neo4jClient,
     scores: Dict[str, float],
     directory: Union[None, Path, str] = None,
+    *,
+    client: Neo4jClient,
     **kwargs,
 ) -> pd.DataFrame:
     """Run GSEA with gene sets for each Gene Ontolgy term.
@@ -205,17 +211,19 @@ def go_gsea(
         A pandas dataframe with the GSEA results
     """
     return gsea(
-        gene_sets=get_go(client),
+        gene_sets=get_go(client=client),
         scores=scores,
         directory=directory,
         **kwargs,
     )
 
 
+@autoclient
 def indra_upstream_gsea(
-    client: Neo4jClient,
     scores: Dict[str, float],
     directory: Union[None, Path, str] = None,
+    *,
+    client: Neo4jClient,
     **kwargs,
 ) -> pd.DataFrame:
     """Run GSEA for each entry in the INDRA database and the set
@@ -240,17 +248,19 @@ def indra_upstream_gsea(
         A pandas dataframe with the GSEA results
     """
     return gsea(
-        gene_sets=get_entity_to_targets(client),
+        gene_sets=get_entity_to_targets(client=client),
         scores=scores,
         directory=directory,
         **kwargs,
     )
 
 
+@autoclient
 def indra_downstream_gsea(
-    client: Neo4jClient,
     scores: Dict[str, float],
     directory: Union[None, Path, str] = None,
+    *,
+    client: Neo4jClient,
     **kwargs,
 ) -> pd.DataFrame:
     """Run GSEA for each entry in the INDRA database and the set
@@ -275,7 +285,7 @@ def indra_downstream_gsea(
         A pandas dataframe with the GSEA results
     """
     return gsea(
-        gene_sets=get_entity_to_regulators(client),
+        gene_sets=get_entity_to_regulators(client=client),
         scores=scores,
         directory=directory,
         **kwargs,

--- a/src/indra_cogex/client/enrichment/continuous.py
+++ b/src/indra_cogex/client/enrichment/continuous.py
@@ -110,7 +110,7 @@ def get_rat_scores(
     return df[score_column_name].to_dict()
 
 
-@autoclient
+@autoclient()
 def wikipathways_gsea(
     scores: Dict[str, float],
     directory: Union[None, Path, str] = None,
@@ -146,7 +146,7 @@ def wikipathways_gsea(
     )
 
 
-@autoclient
+@autoclient()
 def reactome_gsea(
     scores: Dict[str, float],
     directory: Union[None, Path, str] = None,
@@ -182,7 +182,7 @@ def reactome_gsea(
     )
 
 
-@autoclient
+@autoclient()
 def go_gsea(
     scores: Dict[str, float],
     directory: Union[None, Path, str] = None,
@@ -218,7 +218,7 @@ def go_gsea(
     )
 
 
-@autoclient
+@autoclient()
 def indra_upstream_gsea(
     scores: Dict[str, float],
     directory: Union[None, Path, str] = None,
@@ -255,7 +255,7 @@ def indra_upstream_gsea(
     )
 
 
-@autoclient
+@autoclient()
 def indra_downstream_gsea(
     scores: Dict[str, float],
     directory: Union[None, Path, str] = None,

--- a/src/indra_cogex/client/enrichment/discrete.py
+++ b/src/indra_cogex/client/enrichment/discrete.py
@@ -2,7 +2,6 @@
 
 """A collection of analyses possible on gene lists (of HGNC identifiers)."""
 
-from functools import lru_cache
 from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 import numpy as np
@@ -17,7 +16,7 @@ from indra_cogex.client.enrichment.utils import (
     get_reactome,
     get_wikipathways,
 )
-from indra_cogex.client.neo4j_client import Neo4jClient
+from indra_cogex.client.neo4j_client import Neo4jClient, autoclient
 from indra_cogex.client.queries import get_genes_for_go_term
 
 __all__ = [
@@ -78,7 +77,7 @@ def _prepare_hypergeometric_test(
     )
 
 
-@lru_cache(maxsize=1)
+@autoclient(cache=True)
 def count_human_genes(client: Neo4jClient) -> int:
     """Count the number of HGNC genes in neo4j."""
     query = f"""\

--- a/src/indra_cogex/client/enrichment/discrete.py
+++ b/src/indra_cogex/client/enrichment/discrete.py
@@ -3,7 +3,7 @@
 """A collection of analyses possible on gene lists (of HGNC identifiers)."""
 
 from functools import lru_cache
-from typing import Dict, Iterable, List, Mapping, Optional, Set, Tuple
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 import numpy as np
 import pandas as pd
@@ -28,7 +28,6 @@ __all__ = [
     "indra_upstream_ora",
 ]
 
-
 # fmt: off
 #: This example list comes from human genes associated with COVID-19
 #: (https://bgee.org/?page=top_anat#/result/9bbddda9dea22c21edcada56ad552a35cb8e29a7/)
@@ -39,6 +38,8 @@ EXAMPLE_GENE_IDS = [
     "10498", "10819", "6769", "11120", "11133", "11432", "11584", "18348", "11849", "28948", "11876", "11878",
     "11985", "20820", "12647", "20593", "12713"
 ]
+
+
 # fmt: on
 
 
@@ -97,7 +98,7 @@ def gene_ontology_single_ora(
     1. Look up genes associated with GO term or child terms
     2. Run ORA and return results
     """
-    count = count_human_genes(client)
+    count = count_human_genes(client=client)
     go_gene_ids = {
         gene.db_id
         for gene in get_genes_for_go_term(
@@ -153,24 +154,28 @@ def _do_ora(
 
 def go_ora(client: Neo4jClient, gene_ids: Iterable[str], **kwargs) -> pd.DataFrame:
     """Calculate over-representation on all GO terms."""
-    count = count_human_genes(client)
-    return _do_ora(get_go(client), gene_ids=gene_ids, count=count, **kwargs)
+    count = count_human_genes(client=client)
+    return _do_ora(get_go(client=client), gene_ids=gene_ids, count=count, **kwargs)
 
 
 def wikipathways_ora(
     client: Neo4jClient, gene_ids: Iterable[str], **kwargs
 ) -> pd.DataFrame:
     """Calculate over-representation on all WikiPathway pathways."""
-    count = count_human_genes(client)
-    return _do_ora(get_wikipathways(client), gene_ids=gene_ids, count=count, **kwargs)
+    count = count_human_genes(client=client)
+    return _do_ora(
+        get_wikipathways(client=client), gene_ids=gene_ids, count=count, **kwargs
+    )
 
 
 def reactome_ora(
     client: Neo4jClient, gene_ids: Iterable[str], **kwargs
 ) -> pd.DataFrame:
     """Calculate over-representation on all Reactome pathways."""
-    count = count_human_genes(client)
-    return _do_ora(get_reactome(client), gene_ids=gene_ids, count=count, **kwargs)
+    count = count_human_genes(client=client)
+    return _do_ora(
+        get_reactome(client=client), gene_ids=gene_ids, count=count, **kwargs
+    )
 
 
 def indra_downstream_ora(
@@ -181,9 +186,12 @@ def indra_downstream_ora(
     based on the genes that are causally upstream of it and how
     they compare to the query gene set.
     """
-    count = count_human_genes(client)
+    count = count_human_genes(client=client)
     return _do_ora(
-        get_entity_to_regulators(client), gene_ids=gene_ids, count=count, **kwargs
+        get_entity_to_regulators(client=client),
+        gene_ids=gene_ids,
+        count=count,
+        **kwargs,
     )
 
 
@@ -195,27 +203,43 @@ def indra_upstream_ora(
     based on the set of genes that it regulates and how
     they compare to the query gene set.
     """
-    count = count_human_genes(client)
+    count = count_human_genes(client=client)
     return _do_ora(
-        get_entity_to_targets(client), gene_ids=gene_ids, count=count, **kwargs
+        get_entity_to_targets(client=client), gene_ids=gene_ids, count=count, **kwargs
     )
 
 
 def main():
     client = Neo4jClient()
     print("\nGO Enrichment\n")
-    print(go_ora(client, EXAMPLE_GENE_IDS).head(15).to_markdown(index=False))
+    print(
+        go_ora(client=client, gene_ids=EXAMPLE_GENE_IDS)
+        .head(15)
+        .to_markdown(index=False)
+    )
     print("\n## WikiPathways Enrichment\n")
-    print(wikipathways_ora(client, EXAMPLE_GENE_IDS).head(15).to_markdown(index=False))
+    print(
+        wikipathways_ora(client=client, gene_ids=EXAMPLE_GENE_IDS)
+        .head(15)
+        .to_markdown(index=False)
+    )
     print("\n## Reactome Enrichment\n")
-    print(reactome_ora(client, EXAMPLE_GENE_IDS).head(15).to_markdown(index=False))
+    print(
+        reactome_ora(client=client, gene_ids=EXAMPLE_GENE_IDS)
+        .head(15)
+        .to_markdown(index=False)
+    )
     print("\n## INDRA Upstream Enrichment\n")
     print(
-        indra_upstream_ora(client, EXAMPLE_GENE_IDS).head(15).to_markdown(index=False)
+        indra_upstream_ora(client=client, gene_ids=EXAMPLE_GENE_IDS)
+        .head(15)
+        .to_markdown(index=False)
     )
     print("\n## INDRA Downstream Enrichment\n")
     print(
-        indra_downstream_ora(client, EXAMPLE_GENE_IDS).head(15).to_markdown(index=False)
+        indra_downstream_ora(client=client, gene_ids=EXAMPLE_GENE_IDS)
+        .head(15)
+        .to_markdown(index=False)
     )
 
 

--- a/src/indra_cogex/client/enrichment/signed.py
+++ b/src/indra_cogex/client/enrichment/signed.py
@@ -44,7 +44,7 @@ POSITIVE_STMTS = ["Activation", "IncreaseAmount"]
 NEGATIVE_STMTS = ["Inhibition", "DecreaseAmount"]
 
 
-@autoclient
+@autoclient()
 def reverse_causal_reasoning(
     positive_hgnc_ids: Iterable[str],
     negative_hgnc_ids: Iterable[str],

--- a/src/indra_cogex/client/enrichment/signed.py
+++ b/src/indra_cogex/client/enrichment/signed.py
@@ -11,7 +11,7 @@ import pystow
 import scipy.stats
 
 from indra_cogex.client.enrichment.utils import collect_gene_sets
-from indra_cogex.client.neo4j_client import Neo4jClient
+from indra_cogex.client.neo4j_client import Neo4jClient, autoclient
 
 HERE = Path(__file__).parent.resolve()
 
@@ -44,8 +44,8 @@ POSITIVE_STMTS = ["Activation", "IncreaseAmount"]
 NEGATIVE_STMTS = ["Inhibition", "DecreaseAmount"]
 
 
+@autoclient
 def reverse_causal_reasoning(
-    client: Neo4jClient,
     positive_hgnc_ids: Iterable[str],
     negative_hgnc_ids: Iterable[str],
     minimum_size: int = 4,
@@ -53,6 +53,8 @@ def reverse_causal_reasoning(
     negative_stmts: Optional[Iterable[str]] = None,
     alpha: Optional[float] = None,
     keep_insignificant: bool = True,
+    *,
+    client: Neo4jClient,
 ) -> pd.DataFrame:
     """Implement the Reverse Causal Reasoning algorithm from [catlett2013]_.
 
@@ -93,10 +95,10 @@ def reverse_causal_reasoning(
     positive_hgnc_ids = set(positive_hgnc_ids)
     negative_hgnc_ids = set(negative_hgnc_ids)
     database_positive = collect_gene_sets(
-        client, _query(positive_stmts or POSITIVE_STMTS)
+        client=client, query=_query(positive_stmts or POSITIVE_STMTS)
     )
     database_negative = collect_gene_sets(
-        client, _query(negative_stmts or NEGATIVE_STMTS)
+        client=client, query=_query(negative_stmts or NEGATIVE_STMTS)
     )
     entities = set(database_positive).union(database_negative)
 
@@ -182,7 +184,7 @@ def main():
     """Demonstrate signed gene list functions."""
     client = Neo4jClient()
     df = reverse_causal_reasoning(
-        client,
+        client=client,
         positive_hgnc_ids=EXAMPLE_POSITIVE_HGNC_IDS,
         negative_hgnc_ids=EXAMPLE_NEGATIVE_HGNC_IDS,
     )

--- a/src/indra_cogex/client/enrichment/utils.py
+++ b/src/indra_cogex/client/enrichment/utils.py
@@ -4,7 +4,6 @@
 
 import logging
 from collections import defaultdict
-from functools import lru_cache
 from textwrap import dedent
 from typing import Dict, Set, Tuple
 
@@ -58,7 +57,6 @@ def collect_gene_sets(
 
 
 @autoclient(cache=True)
-@lru_cache(maxsize=1)
 def get_go(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set[str]]:
     """Get GO gene sets.
 

--- a/src/indra_cogex/client/enrichment/utils.py
+++ b/src/indra_cogex/client/enrichment/utils.py
@@ -22,7 +22,7 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-@autoclient
+@autoclient()
 def collect_gene_sets(
     query: str,
     *,
@@ -57,7 +57,7 @@ def collect_gene_sets(
     return dict(curie_to_hgnc_ids)
 
 
-@autoclient
+@autoclient(cache=True)
 @lru_cache(maxsize=1)
 def get_go(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set[str]]:
     """Get GO gene sets.
@@ -83,8 +83,7 @@ def get_go(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set[str]]:
     return collect_gene_sets(client=client, query=query)
 
 
-@autoclient
-@lru_cache(maxsize=1)
+@autoclient(cache=True)
 def get_wikipathways(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set[str]]:
     """Get WikiPathways gene sets.
 
@@ -110,8 +109,7 @@ def get_wikipathways(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set[str]]:
     return collect_gene_sets(client=client, query=query)
 
 
-@autoclient
-@lru_cache(maxsize=1)
+@autoclient(cache=True)
 def get_reactome(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set[str]]:
     """Get Reactome gene sets.
 
@@ -137,8 +135,7 @@ def get_reactome(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set[str]]:
     return collect_gene_sets(client=client, query=query)
 
 
-@autoclient
-@lru_cache(maxsize=1)
+@autoclient(cache=True)
 def get_entity_to_targets(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set[str]]:
     """Get a mapping from each entity in the INDRA database to the set of
     human genes that it regulates.
@@ -170,8 +167,7 @@ def get_entity_to_targets(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set[s
     return collect_gene_sets(client=client, query=query)
 
 
-@autoclient
-@lru_cache(maxsize=1)
+@autoclient(cache=True)
 def get_entity_to_regulators(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set[str]]:
     """Get a mapping from each entity in the INDRA database to the set of
     human genes that are causally upstream of it.

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -866,11 +866,13 @@ def autoclient(*, cache: bool = False, maxsize: Optional[int] = 128):
         client_param = signature.parameters.get("client")
         if client_param is None:
             raise ValueError(
-                "the autoclient decorator can't be applied to a function that doesn't take a neo4j client."
+                "the autoclient decorator can't be applied to a function that"
+                " doesn't take a neo4j client."
             )
         if client_param.kind != inspect.Parameter.KEYWORD_ONLY:
             raise ValueError(
-                "the autoclient decorator can't be applied to a function whose client argument isn't keyword-only"
+                "the autoclient decorator can't be applied to a function whose"
+                " `client` argument isn't keyword-only"
             )
 
         @wraps(func)

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -50,7 +50,9 @@ __all__ = [
 
 
 @autoclient()
-def get_genes_in_tissue(tissue: Tuple[str, str], *, client: Neo4jClient) -> Iterable[Node]:
+def get_genes_in_tissue(
+    tissue: Tuple[str, str], *, client: Neo4jClient
+) -> Iterable[Node]:
     """Return the genes in the given tissue.
 
     Parameters
@@ -74,7 +76,9 @@ def get_genes_in_tissue(tissue: Tuple[str, str], *, client: Neo4jClient) -> Iter
 
 
 @autoclient()
-def get_tissues_for_gene(gene: Tuple[str, str], *, client: Neo4jClient) -> Iterable[Node]:
+def get_tissues_for_gene(
+    gene: Tuple[str, str], *, client: Neo4jClient
+) -> Iterable[Node]:
     """Return the tissues the gene is expressed in.
 
     Parameters
@@ -231,7 +235,9 @@ def is_go_term_for_gene(
 
 
 @autoclient()
-def get_trials_for_drug(drug: Tuple[str, str], *, client: Neo4jClient) -> Iterable[Node]:
+def get_trials_for_drug(
+    drug: Tuple[str, str], *, client: Neo4jClient
+) -> Iterable[Node]:
     """Return the trials for the given drug.
 
     Parameters
@@ -281,7 +287,9 @@ def get_trials_for_disease(
 
 
 @autoclient()
-def get_drugs_for_trial(trial: Tuple[str, str], *, client: Neo4jClient) -> Iterable[Node]:
+def get_drugs_for_trial(
+    trial: Tuple[str, str], *, client: Neo4jClient
+) -> Iterable[Node]:
     """Return the drugs for the given trial.
 
     Parameters
@@ -334,7 +342,9 @@ def get_diseases_for_trial(
 
 
 @autoclient()
-def get_pathways_for_gene(gene: Tuple[str, str], *, client: Neo4jClient) -> Iterable[Node]:
+def get_pathways_for_gene(
+    gene: Tuple[str, str], *, client: Neo4jClient
+) -> Iterable[Node]:
     """Return the pathways for the given gene.
 
     Parameters
@@ -890,7 +900,9 @@ def get_stmts_for_stmt_hashes(
 
 
 @autoclient()
-def _get_mesh_child_terms(mesh_term: Tuple[str, str], *, client: Neo4jClient) -> Set[str]:
+def _get_mesh_child_terms(
+    mesh_term: Tuple[str, str], *, client: Neo4jClient
+) -> Set[str]:
     """Return the children of the given MESH ID.
 
     Parameters

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -6,7 +6,7 @@ from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 import networkx as nx
 from indra.statements import Evidence, Statement
 
-from .neo4j_client import Neo4jClient
+from .neo4j_client import Neo4jClient, autoclient
 from ..representation import Node, indra_stmts_from_relations, norm_id
 
 logger = logging.getLogger(__name__)
@@ -903,7 +903,8 @@ def _get_ev_dict_from_hash_ev_query(
     return dict(ev_dict)
 
 
-def get_node_counter(client: Neo4jClient) -> Counter:
+@autoclient(cache=True)
+def get_node_counter(*, client: Neo4jClient) -> Counter:
     """Get a count of each entity type.
 
     .. warning:: this code assumes all nodes only have one label, as in``label[0]``
@@ -916,7 +917,8 @@ def get_node_counter(client: Neo4jClient) -> Counter:
     )
 
 
-def get_edge_counter(client: Neo4jClient) -> Counter:
+@autoclient(cache=True)
+def get_edge_counter(*, client: Neo4jClient) -> Counter:
     """Get a count of each edge type."""
     return Counter(
         {
@@ -928,7 +930,8 @@ def get_edge_counter(client: Neo4jClient) -> Counter:
     )
 
 
-def get_schema_graph(client: Neo4jClient) -> nx.MultiDiGraph:
+@autoclient(cache=True)
+def get_schema_graph(*, client: Neo4jClient) -> nx.MultiDiGraph:
     """Get a NetworkX graph reflecting the schema of the Neo4j graph.
 
     Generate a PDF diagram (works with PNG and SVG too) with the following::

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -49,7 +49,7 @@ __all__ = [
 # BGee
 
 
-@autoclient
+@autoclient()
 def get_genes_in_tissue(tissue: Tuple[str, str], *, client: Neo4jClient) -> Iterable[Node]:
     """Return the genes in the given tissue.
 
@@ -73,7 +73,7 @@ def get_genes_in_tissue(tissue: Tuple[str, str], *, client: Neo4jClient) -> Iter
     )
 
 
-@autoclient
+@autoclient()
 def get_tissues_for_gene(gene: Tuple[str, str], *, client: Neo4jClient) -> Iterable[Node]:
     """Return the tissues the gene is expressed in.
 
@@ -97,7 +97,7 @@ def get_tissues_for_gene(gene: Tuple[str, str], *, client: Neo4jClient) -> Itera
     )
 
 
-@autoclient
+@autoclient()
 def is_gene_in_tissue(
     gene: Tuple[str, str], tissue: Tuple[str, str], *, client: Neo4jClient
 ) -> bool:
@@ -129,7 +129,7 @@ def is_gene_in_tissue(
 # GO
 
 
-@autoclient
+@autoclient()
 def get_go_terms_for_gene(
     gene: Tuple[str, str], include_indirect=False, *, client: Neo4jClient
 ) -> Iterable[Node]:
@@ -163,7 +163,7 @@ def get_go_terms_for_gene(
     return list(go_terms.values())
 
 
-@autoclient
+@autoclient()
 def get_genes_for_go_term(
     go_term: Tuple[str, str], include_indirect: bool = False, *, client: Neo4jClient
 ) -> Iterable[Node]:
@@ -198,7 +198,7 @@ def get_genes_for_go_term(
     return list(gene_nodes.values())
 
 
-@autoclient
+@autoclient()
 def is_go_term_for_gene(
     gene: Tuple[str, str], go_term: Tuple[str, str], *, client: Neo4jClient
 ) -> bool:
@@ -230,7 +230,7 @@ def is_go_term_for_gene(
 # Trials
 
 
-@autoclient
+@autoclient()
 def get_trials_for_drug(drug: Tuple[str, str], *, client: Neo4jClient) -> Iterable[Node]:
     """Return the trials for the given drug.
 
@@ -254,7 +254,7 @@ def get_trials_for_drug(drug: Tuple[str, str], *, client: Neo4jClient) -> Iterab
     )
 
 
-@autoclient
+@autoclient()
 def get_trials_for_disease(
     disease: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Node]:
@@ -280,7 +280,7 @@ def get_trials_for_disease(
     )
 
 
-@autoclient
+@autoclient()
 def get_drugs_for_trial(trial: Tuple[str, str], *, client: Neo4jClient) -> Iterable[Node]:
     """Return the drugs for the given trial.
 
@@ -304,7 +304,7 @@ def get_drugs_for_trial(trial: Tuple[str, str], *, client: Neo4jClient) -> Itera
     )
 
 
-@autoclient
+@autoclient()
 def get_diseases_for_trial(
     trial: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Node]:
@@ -333,7 +333,7 @@ def get_diseases_for_trial(
 # Pathways
 
 
-@autoclient
+@autoclient()
 def get_pathways_for_gene(gene: Tuple[str, str], *, client: Neo4jClient) -> Iterable[Node]:
     """Return the pathways for the given gene.
 
@@ -357,7 +357,7 @@ def get_pathways_for_gene(gene: Tuple[str, str], *, client: Neo4jClient) -> Iter
     )
 
 
-@autoclient
+@autoclient()
 def get_genes_for_pathway(
     pathway: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Node]:
@@ -383,7 +383,7 @@ def get_genes_for_pathway(
     )
 
 
-@autoclient
+@autoclient()
 def is_gene_in_pathway(
     gene: Tuple[str, str], pathway: Tuple[str, str], *, client: Neo4jClient
 ) -> bool:
@@ -415,7 +415,7 @@ def is_gene_in_pathway(
 # Side effects
 
 
-@autoclient
+@autoclient()
 def get_side_effects_for_drug(
     drug: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Node]:
@@ -441,7 +441,7 @@ def get_side_effects_for_drug(
     )
 
 
-@autoclient
+@autoclient()
 def get_drugs_for_side_effect(
     side_effect: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Node]:
@@ -467,7 +467,7 @@ def get_drugs_for_side_effect(
     )
 
 
-@autoclient
+@autoclient()
 def is_side_effect_for_drug(
     drug: Tuple[str, str], side_effect: Tuple[str, str], *, client: Neo4jClient
 ) -> bool:
@@ -499,7 +499,7 @@ def is_side_effect_for_drug(
 # Ontology
 
 
-@autoclient
+@autoclient()
 def get_ontology_child_terms(
     term: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Node]:
@@ -520,7 +520,7 @@ def get_ontology_child_terms(
     return client.get_predecessors(term, relations={"isa", "partof"})
 
 
-@autoclient
+@autoclient()
 def get_ontology_parent_terms(
     term: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Node]:
@@ -541,7 +541,7 @@ def get_ontology_parent_terms(
     return client.get_successors(term, relations={"isa", "partof"})
 
 
-@autoclient
+@autoclient()
 def isa_or_partof(
     term: Tuple[str, str], parent: Tuple[str, str], *, client: Neo4jClient
 ) -> bool:
@@ -568,7 +568,7 @@ def isa_or_partof(
 # MESH / PMID
 
 
-@autoclient
+@autoclient()
 def get_pmids_for_mesh(
     mesh_term: Tuple[str, str], include_child_terms: bool = True, *, client: Neo4jClient
 ) -> Iterable[Node]:
@@ -620,7 +620,7 @@ def get_pmids_for_mesh(
     return [client.neo4j_to_node(r[0]) for r in client.query_tx(query)]
 
 
-@autoclient
+@autoclient()
 def get_mesh_ids_for_pmid(
     pmid_term: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Node]:
@@ -649,7 +649,7 @@ def get_mesh_ids_for_pmid(
     )
 
 
-@autoclient
+@autoclient()
 def get_evidences_for_mesh(
     mesh_term: Tuple[str, str], include_child_terms: bool = True, *, client: Neo4jClient
 ) -> Dict[str, List[Evidence]]:
@@ -697,7 +697,7 @@ def get_evidences_for_mesh(
     return _get_ev_dict_from_hash_ev_query(client.query_tx(query))
 
 
-@autoclient
+@autoclient()
 def get_evidences_for_stmt_hash(
     stmt_hash: Union[str, int], *, client: Neo4jClient
 ) -> Iterable[Evidence]:
@@ -724,7 +724,7 @@ def get_evidences_for_stmt_hash(
     return [Evidence._from_json(ev_json) for ev_json in ev_jsons]
 
 
-@autoclient
+@autoclient()
 def get_evidences_for_stmt_hashes(
     stmt_hashes: Iterable[Union[str, int]], *, client: Neo4jClient
 ) -> Dict[str, List[Evidence]]:
@@ -756,7 +756,7 @@ def get_evidences_for_stmt_hashes(
     return _get_ev_dict_from_hash_ev_query(client.query_tx(query))
 
 
-@autoclient
+@autoclient()
 def get_stmts_for_pmid(
     pmid_term: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Statement]:
@@ -797,7 +797,7 @@ def get_stmts_for_pmid(
     return get_stmts_for_stmt_hashes(stmt_hashes, ev_dict, client=client)
 
 
-@autoclient
+@autoclient()
 def get_stmts_for_mesh(
     mesh_term: Tuple[str, str], include_child_terms: bool = True, *, client: Neo4jClient
 ) -> Iterable[Statement]:
@@ -822,7 +822,7 @@ def get_stmts_for_mesh(
     return get_stmts_for_stmt_hashes(hashes, ev_dict, client=client)
 
 
-@autoclient
+@autoclient()
 def get_stmts_for_stmt_hashes(
     stmt_hashes: Iterable[str],
     evidence_map: Optional[Dict[str, List[Evidence]]] = None,
@@ -889,7 +889,7 @@ def get_stmts_for_stmt_hashes(
     return list(stmts.values())
 
 
-@autoclient
+@autoclient()
 def _get_mesh_child_terms(mesh_term: Tuple[str, str], *, client: Neo4jClient) -> Set[str]:
     """Return the children of the given MESH ID.
 

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -549,8 +549,9 @@ def isa_or_partof(
 # MESH / PMID
 
 
+@autoclient
 def get_pmids_for_mesh(
-    client: Neo4jClient, mesh_term: Tuple[str, str], include_child_terms: bool = True
+    mesh_term: Tuple[str, str], include_child_terms: bool = True, *, client: Neo4jClient
 ) -> Iterable[Node]:
     """Return the PubMed IDs for the given MESH term.
 
@@ -600,8 +601,9 @@ def get_pmids_for_mesh(
     return [client.neo4j_to_node(r[0]) for r in client.query_tx(query)]
 
 
+@autoclient
 def get_mesh_ids_for_pmid(
-    client: Neo4jClient, pmid_term: Tuple[str, str]
+    pmid_term: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Node]:
     """Return the MESH terms for the given PubMed ID.
 
@@ -628,8 +630,9 @@ def get_mesh_ids_for_pmid(
     )
 
 
+@autoclient
 def get_evidences_for_mesh(
-    client: Neo4jClient, mesh_term: Tuple[str, str], include_child_terms: bool = True
+    mesh_term: Tuple[str, str], include_child_terms: bool = True, *, client: Neo4jClient
 ) -> Dict[str, List[Evidence]]:
     """Return the evidence objects for the given MESH term.
 
@@ -675,8 +678,9 @@ def get_evidences_for_mesh(
     return _get_ev_dict_from_hash_ev_query(client.query_tx(query))
 
 
+@autoclient
 def get_evidences_for_stmt_hash(
-    client: Neo4jClient, stmt_hash: Union[str, int]
+    stmt_hash: Union[str, int], *, client: Neo4jClient
 ) -> Iterable[Evidence]:
     """Return the matching evidence objects for the given statement hash.
 
@@ -701,8 +705,9 @@ def get_evidences_for_stmt_hash(
     return [Evidence._from_json(ev_json) for ev_json in ev_jsons]
 
 
+@autoclient
 def get_evidences_for_stmt_hashes(
-    client: Neo4jClient, stmt_hashes: Iterable[Union[str, int]]
+    stmt_hashes: Iterable[Union[str, int]], *, client: Neo4jClient
 ) -> Dict[str, List[Evidence]]:
     """Return the matching evidence objects for the given statement hashes.
 
@@ -732,8 +737,9 @@ def get_evidences_for_stmt_hashes(
     return _get_ev_dict_from_hash_ev_query(client.query_tx(query))
 
 
+@autoclient
 def get_stmts_for_pmid(
-    client: Neo4jClient, pmid_term: Tuple[str, str]
+    pmid_term: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Statement]:
     """Return the statements with evidence from the given PubMed ID.
 
@@ -772,8 +778,9 @@ def get_stmts_for_pmid(
     return get_stmts_for_stmt_hashes(client, stmt_hashes, ev_dict)
 
 
+@autoclient
 def get_stmts_for_mesh(
-    client: Neo4jClient, mesh_term: Tuple[str, str], include_child_terms: bool = True
+    mesh_term: Tuple[str, str], include_child_terms: bool = True, *, client: Neo4jClient
 ) -> Iterable[Statement]:
     """Return the statements with evidence for the given MESH ID.
 
@@ -796,10 +803,12 @@ def get_stmts_for_mesh(
     return get_stmts_for_stmt_hashes(client, hashes, ev_dict)
 
 
+@autoclient
 def get_stmts_for_stmt_hashes(
-    client: Neo4jClient,
     stmt_hashes: Iterable[str],
     evidence_map: Optional[Dict[str, List[Evidence]]] = None,
+    *,
+    client: Neo4jClient,
 ) -> Iterable[Statement]:
     """Return the statements for the given statement hashes.
 

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -775,7 +775,7 @@ def get_stmts_for_pmid(
     result = client.query_tx(hash_query)
     ev_dict = _get_ev_dict_from_hash_ev_query(result)
     stmt_hashes = set(ev_dict.keys())
-    return get_stmts_for_stmt_hashes(client, stmt_hashes, ev_dict)
+    return get_stmts_for_stmt_hashes(stmt_hashes, ev_dict, client=client)
 
 
 @autoclient
@@ -798,9 +798,9 @@ def get_stmts_for_mesh(
     :
         The statements for the given MESH ID.
     """
-    ev_dict = get_evidences_for_mesh(client, mesh_term, include_child_terms)
+    ev_dict = get_evidences_for_mesh(mesh_term, include_child_terms, client=client)
     hashes = list(ev_dict.keys())
-    return get_stmts_for_stmt_hashes(client, hashes, ev_dict)
+    return get_stmts_for_stmt_hashes(hashes, ev_dict, client=client)
 
 
 @autoclient
@@ -850,7 +850,7 @@ def get_stmts_for_stmt_hashes(
 
     # Get the evidence objects for the given statement hashes
     if missing_hashes:
-        new_evidences = get_evidences_for_stmt_hashes(client, stmt_hashes)
+        new_evidences = get_evidences_for_stmt_hashes(stmt_hashes, client=client)
         if evidence_map:
             evidence_map.update(new_evidences)
         else:

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -49,7 +49,8 @@ __all__ = [
 # BGee
 
 
-def get_genes_in_tissue(client: Neo4jClient, tissue: Tuple[str, str]) -> Iterable[Node]:
+@autoclient
+def get_genes_in_tissue(tissue: Tuple[str, str], *, client: Neo4jClient) -> Iterable[Node]:
     """Return the genes in the given tissue.
 
     Parameters
@@ -72,7 +73,8 @@ def get_genes_in_tissue(client: Neo4jClient, tissue: Tuple[str, str]) -> Iterabl
     )
 
 
-def get_tissues_for_gene(client: Neo4jClient, gene: Tuple[str, str]) -> Iterable[Node]:
+@autoclient
+def get_tissues_for_gene(gene: Tuple[str, str], *, client: Neo4jClient) -> Iterable[Node]:
     """Return the tissues the gene is expressed in.
 
     Parameters
@@ -95,8 +97,9 @@ def get_tissues_for_gene(client: Neo4jClient, gene: Tuple[str, str]) -> Iterable
     )
 
 
+@autoclient
 def is_gene_in_tissue(
-    client: Neo4jClient, gene: Tuple[str, str], tissue: Tuple[str, str]
+    gene: Tuple[str, str], tissue: Tuple[str, str], *, client: Neo4jClient
 ) -> bool:
     """Return True if the gene is expressed in the given tissue.
 
@@ -126,8 +129,9 @@ def is_gene_in_tissue(
 # GO
 
 
+@autoclient
 def get_go_terms_for_gene(
-    client: Neo4jClient, gene: Tuple[str, str], include_indirect=False
+    gene: Tuple[str, str], include_indirect=False, *, client: Neo4jClient
 ) -> Iterable[Node]:
     """Return the GO terms for the given gene.
 
@@ -159,8 +163,9 @@ def get_go_terms_for_gene(
     return list(go_terms.values())
 
 
+@autoclient
 def get_genes_for_go_term(
-    client: Neo4jClient, go_term: Tuple[str, str], include_indirect: bool = False
+    go_term: Tuple[str, str], include_indirect: bool = False, *, client: Neo4jClient
 ) -> Iterable[Node]:
     """Return the genes associated with the given GO term.
 
@@ -193,8 +198,9 @@ def get_genes_for_go_term(
     return list(gene_nodes.values())
 
 
+@autoclient
 def is_go_term_for_gene(
-    client: Neo4jClient, gene: Tuple[str, str], go_term: Tuple[str, str]
+    gene: Tuple[str, str], go_term: Tuple[str, str], *, client: Neo4jClient
 ) -> bool:
     """Return True if the given GO term is associated with the given gene.
 
@@ -224,7 +230,8 @@ def is_go_term_for_gene(
 # Trials
 
 
-def get_trials_for_drug(client: Neo4jClient, drug: Tuple[str, str]) -> Iterable[Node]:
+@autoclient
+def get_trials_for_drug(drug: Tuple[str, str], *, client: Neo4jClient) -> Iterable[Node]:
     """Return the trials for the given drug.
 
     Parameters
@@ -247,8 +254,9 @@ def get_trials_for_drug(client: Neo4jClient, drug: Tuple[str, str]) -> Iterable[
     )
 
 
+@autoclient
 def get_trials_for_disease(
-    client: Neo4jClient, disease: Tuple[str, str]
+    disease: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Node]:
     """Return the trials for the given disease.
 
@@ -272,7 +280,8 @@ def get_trials_for_disease(
     )
 
 
-def get_drugs_for_trial(client: Neo4jClient, trial: Tuple[str, str]) -> Iterable[Node]:
+@autoclient
+def get_drugs_for_trial(trial: Tuple[str, str], *, client: Neo4jClient) -> Iterable[Node]:
     """Return the drugs for the given trial.
 
     Parameters
@@ -295,8 +304,9 @@ def get_drugs_for_trial(client: Neo4jClient, trial: Tuple[str, str]) -> Iterable
     )
 
 
+@autoclient
 def get_diseases_for_trial(
-    client: Neo4jClient, trial: Tuple[str, str]
+    trial: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Node]:
     """Return the diseases for the given trial.
 
@@ -323,7 +333,8 @@ def get_diseases_for_trial(
 # Pathways
 
 
-def get_pathways_for_gene(client: Neo4jClient, gene: Tuple[str, str]) -> Iterable[Node]:
+@autoclient
+def get_pathways_for_gene(gene: Tuple[str, str], *, client: Neo4jClient) -> Iterable[Node]:
     """Return the pathways for the given gene.
 
     Parameters
@@ -346,8 +357,9 @@ def get_pathways_for_gene(client: Neo4jClient, gene: Tuple[str, str]) -> Iterabl
     )
 
 
+@autoclient
 def get_genes_for_pathway(
-    client: Neo4jClient, pathway: Tuple[str, str]
+    pathway: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Node]:
     """Return the genes for the given pathway.
 
@@ -371,8 +383,9 @@ def get_genes_for_pathway(
     )
 
 
+@autoclient
 def is_gene_in_pathway(
-    client: Neo4jClient, gene: Tuple[str, str], pathway: Tuple[str, str]
+    gene: Tuple[str, str], pathway: Tuple[str, str], *, client: Neo4jClient
 ) -> bool:
     """Return True if the gene is in the given pathway.
 
@@ -402,8 +415,9 @@ def is_gene_in_pathway(
 # Side effects
 
 
+@autoclient
 def get_side_effects_for_drug(
-    client: Neo4jClient, drug: Tuple[str, str]
+    drug: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Node]:
     """Return the side effects for the given drug.
 
@@ -427,8 +441,9 @@ def get_side_effects_for_drug(
     )
 
 
+@autoclient
 def get_drugs_for_side_effect(
-    client: Neo4jClient, side_effect: Tuple[str, str]
+    side_effect: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Node]:
     """Return the drugs for the given side effect.
 
@@ -452,8 +467,9 @@ def get_drugs_for_side_effect(
     )
 
 
+@autoclient
 def is_side_effect_for_drug(
-    client: Neo4jClient, drug: Tuple[str, str], side_effect: Tuple[str, str]
+    drug: Tuple[str, str], side_effect: Tuple[str, str], *, client: Neo4jClient
 ) -> bool:
     """Return True if the given side effect is associated with the given drug.
 
@@ -483,8 +499,9 @@ def is_side_effect_for_drug(
 # Ontology
 
 
+@autoclient
 def get_ontology_child_terms(
-    client: Neo4jClient, term: Tuple[str, str]
+    term: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Node]:
     """Return the child terms of the given term.
 
@@ -503,8 +520,9 @@ def get_ontology_child_terms(
     return client.get_predecessors(term, relations={"isa", "partof"})
 
 
+@autoclient
 def get_ontology_parent_terms(
-    client: Neo4jClient, term: Tuple[str, str]
+    term: Tuple[str, str], *, client: Neo4jClient
 ) -> Iterable[Node]:
     """Return the parent terms of the given term.
 
@@ -523,8 +541,9 @@ def get_ontology_parent_terms(
     return client.get_successors(term, relations={"isa", "partof"})
 
 
+@autoclient
 def isa_or_partof(
-    client: Neo4jClient, term: Tuple[str, str], parent: Tuple[str, str]
+    term: Tuple[str, str], parent: Tuple[str, str], *, client: Neo4jClient
 ) -> bool:
     """Return True if the given term is a child of the given parent.
 
@@ -542,7 +561,7 @@ def isa_or_partof(
     :
         True if the given term is a child term of the given parent.
     """
-    term_parents = get_ontology_parent_terms(client, term)
+    term_parents = get_ontology_parent_terms(term, client=client)
     return any(parent == parent_term.grounding() for parent_term in term_parents)
 
 
@@ -578,7 +597,7 @@ def get_pmids_for_mesh(
     # slower for this specific query, so we do an optimized query that is
     # basically equivalent instead.
     if include_child_terms:
-        child_terms = _get_mesh_child_terms(client, mesh_term)
+        child_terms = _get_mesh_child_terms(mesh_term, client=client)
     else:
         child_terms = set()
 
@@ -656,7 +675,7 @@ def get_evidences_for_mesh(
 
     norm_mesh = norm_id(*mesh_term)
     if include_child_terms:
-        child_terms = _get_mesh_child_terms(client, mesh_term)
+        child_terms = _get_mesh_child_terms(mesh_term, client=client)
     else:
         child_terms = set()
 
@@ -870,7 +889,8 @@ def get_stmts_for_stmt_hashes(
     return list(stmts.values())
 
 
-def _get_mesh_child_terms(client: Neo4jClient, mesh_term: Tuple[str, str]) -> Set[str]:
+@autoclient
+def _get_mesh_child_terms(mesh_term: Tuple[str, str], *, client: Neo4jClient) -> Set[str]:
     """Return the children of the given MESH ID.
 
     Parameters

--- a/src/indra_cogex/client/subnetwork.py
+++ b/src/indra_cogex/client/subnetwork.py
@@ -62,6 +62,6 @@ def indra_subnetwork_tissue(
     :
         The subnetwork induced by the given nodes and expressed in the given tissue.
     """
-    genes = get_genes_in_tissue(client, tissue)
+    genes = get_genes_in_tissue(client=client, tissue=tissue)
     relevant_genes = {g.grounding() for g in genes} & set(nodes)
     return indra_subnetwork(client, relevant_genes)

--- a/tests/test_autoclient.py
+++ b/tests/test_autoclient.py
@@ -1,0 +1,42 @@
+"""Tests for the autoclient decorator."""
+
+import pytest
+
+from indra_cogex.client.neo4j_client import autoclient
+from indra_cogex.representation import Node
+
+
+def test_missing():
+    """Test failure when missing the "client" argument."""
+    with pytest.raises(ValueError):
+        @autoclient
+        def func(something_else):
+            pass
+
+
+def test_positional_exception():
+    """Test failure on a positional argument."""
+    with pytest.raises(ValueError):
+        @autoclient
+        def func(client):
+            pass
+
+
+def test_autoclient():
+    """Test failure on a positional argument."""
+
+    @autoclient
+    def get_tissues_for_gene(gene, *, client):
+        return client.get_targets(
+            gene,
+            relation="expressed_in",
+            source_type="BioEntity",
+            target_type="BioEntity",
+        )
+
+    tissues = get_tissues_for_gene(("HGNC", "9896"))
+    assert tissues
+    node0 = tissues[0]
+    assert isinstance(node0, Node)
+    assert node0.db_ns in {"UBERON", "CL"}
+    assert ("UBERON", "UBERON:0002349") in {g.grounding() for g in tissues}

--- a/tests/test_autoclient.py
+++ b/tests/test_autoclient.py
@@ -12,6 +12,7 @@ from indra_cogex.representation import Node
 def test_missing():
     """Test failure when missing the "client" argument."""
     with pytest.raises(ValueError):
+
         @autoclient()
         def func(something_else):
             pass
@@ -20,6 +21,7 @@ def test_missing():
 def test_positional_exception():
     """Test failure on a positional argument."""
     with pytest.raises(ValueError):
+
         @autoclient()
         def func(client):
             pass
@@ -40,6 +42,16 @@ def test_autoclient():
     assert not hasattr(get_tissues_for_gene, "cache_info"), "caching is not enabled"
 
     tissues = get_tissues_for_gene(("HGNC", "9896"))
+    _check_tissues(tissues)
+
+    # Test what happens when you pass in your own client
+    client = Neo4jClient()
+    tissues = get_tissues_for_gene(("HGNC", "9896"), client=client)
+    _check_tissues(tissues)
+    assert client.session is not None
+
+
+def _check_tissues(tissues):
     assert tissues
     node0 = tissues[0]
     assert isinstance(node0, Node)

--- a/tests/test_autoclient.py
+++ b/tests/test_autoclient.py
@@ -1,15 +1,18 @@
 """Tests for the autoclient decorator."""
 
+from collections import Counter
+from typing import Tuple
+
 import pytest
 
-from indra_cogex.client.neo4j_client import autoclient
+from indra_cogex.client.neo4j_client import Neo4jClient, autoclient
 from indra_cogex.representation import Node
 
 
 def test_missing():
     """Test failure when missing the "client" argument."""
     with pytest.raises(ValueError):
-        @autoclient
+        @autoclient()
         def func(something_else):
             pass
 
@@ -17,16 +20,16 @@ def test_missing():
 def test_positional_exception():
     """Test failure on a positional argument."""
     with pytest.raises(ValueError):
-        @autoclient
+        @autoclient()
         def func(client):
             pass
 
 
 def test_autoclient():
-    """Test failure on a positional argument."""
+    """Test a successful application of the autoclient decorator."""
 
-    @autoclient
-    def get_tissues_for_gene(gene, *, client):
+    @autoclient()
+    def get_tissues_for_gene(gene: Tuple[str, str], *, client: Neo4jClient):
         return client.get_targets(
             gene,
             relation="expressed_in",
@@ -34,9 +37,31 @@ def test_autoclient():
             target_type="BioEntity",
         )
 
+    assert not hasattr(get_tissues_for_gene, "cache_info"), "caching is not enabled"
+
     tissues = get_tissues_for_gene(("HGNC", "9896"))
     assert tissues
     node0 = tissues[0]
     assert isinstance(node0, Node)
     assert node0.db_ns in {"UBERON", "CL"}
     assert ("UBERON", "UBERON:0002349") in {g.grounding() for g in tissues}
+
+
+def test_autoclient_cached():
+    """Test caching a function with autoclient."""
+
+    @autoclient(cache=True)
+    def get_node_count(*, client: Neo4jClient) -> Counter:
+        return Counter(
+            {
+                label[0]: client.query_tx(f"MATCH (n:{label[0]}) RETURN count(*)")[0][0]
+                for label in client.query_tx("call db.labels();")
+            }
+        )
+
+    assert hasattr(get_node_count, "cache_info"), "caching should be enabled"
+    node_counts = get_node_count()
+    assert isinstance(node_counts, Counter)
+    assert "BioEntity" in node_counts
+    assert all(isinstance(key, str) for key in node_counts.keys())
+    assert all(isinstance(key, int) for key in node_counts.values())

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -209,7 +209,7 @@ def test_isa_or_partof():
 def test_get_pmids_for_mesh():
     # Single query
     client = _get_client()
-    pmids = get_pmids_for_mesh(client, ("MESH", "D015002"))
+    pmids = get_pmids_for_mesh(("MESH", "D015002"), client=client)
     assert pmids
     assert isinstance(pmids[0], Node)
     assert pmids[0].db_ns == "PUBMED"
@@ -221,7 +221,7 @@ def test_get_mesh_ids_for_pmid():
     # Single query
     client = _get_client()
     pmid = ("PUBMED", "27890007")
-    mesh_ids = get_mesh_ids_for_pmid(client, pmid)
+    mesh_ids = get_mesh_ids_for_pmid(pmid, client=client)
     assert mesh_ids
     assert isinstance(mesh_ids[0], Node)
     assert mesh_ids[0].db_ns == "MESH"
@@ -232,7 +232,7 @@ def test_get_mesh_ids_for_pmid():
 def test_get_evidence_obj_for_mesh_id():
     client = _get_client()
     mesh_id = ("MESH", "D015002")
-    evidence_dict = get_evidences_for_mesh(client, mesh_id)
+    evidence_dict = get_evidences_for_mesh(mesh_id, client=client)
     assert len(evidence_dict)
     assert isinstance(list(evidence_dict.values())[0][0], Evidence)
 
@@ -243,7 +243,7 @@ def test_get_evidence_obj_for_stmt_hash():
     # Single query
     stmt_hash = "12198579805553967"
     client = _get_client()
-    ev_objs = get_evidences_for_stmt_hash(client, stmt_hash)
+    ev_objs = get_evidences_for_stmt_hash(stmt_hash, client=client)
     assert ev_objs
     assert isinstance(ev_objs[0], Evidence)
 
@@ -254,7 +254,7 @@ def test_get_evidence_obj_for_stmt_hashes():
     # Single query
     stmt_hashes = ["12198579805553967", "30651649296901235"]
     client = _get_client()
-    ev_dict = get_evidences_for_stmt_hashes(client, stmt_hashes)
+    ev_dict = get_evidences_for_stmt_hashes(stmt_hashes, client=client)
     assert ev_dict
     assert set(ev_dict.keys()) == {"12198579805553967", "30651649296901235"}
     assert ev_dict["12198579805553967"]
@@ -268,7 +268,7 @@ def test_get_stmts_for_pmid():
     # Two queries: first evidences, then the statements
     client = _get_client()
     pmid = ("PUBMED", "14898026")
-    stmts = get_stmts_for_pmid(client, pmid)
+    stmts = get_stmts_for_pmid(pmid, client=client)
     assert stmts
     assert isinstance(stmts[0], Inhibition)
 
@@ -280,7 +280,7 @@ def test_get_stmts_for_mesh_id_w_children():
     # 2. statements for the evidences in 2
     client = _get_client()
     mesh_id = ("MESH", "D000068236")
-    stmts = get_stmts_for_mesh(client, mesh_id)
+    stmts = get_stmts_for_mesh(mesh_id, client=client)
     assert stmts
     assert isinstance(stmts[0], Activation)
 
@@ -292,7 +292,7 @@ def test_get_stmts_for_mesh_id_wo_children():
     # 2. statements for the evidences in 2
     client = _get_client()
     mesh_id = ("MESH", "D000068236")
-    stmts = get_stmts_for_mesh(client, mesh_id, include_child_terms=False)
+    stmts = get_stmts_for_mesh(mesh_id, include_child_terms=False, client=client)
     assert stmts
     assert isinstance(stmts[0], Activation)
 
@@ -303,6 +303,6 @@ def test_get_stmts_by_hashes():
     # Two queries: first statements, then all the evidence for the statements
     stmt_hashes = ["35279776755000170"]
     client = _get_client()
-    stmts = get_stmts_for_stmt_hashes(client, stmt_hashes)
+    stmts = get_stmts_for_stmt_hashes(stmt_hashes, client=client)
     assert stmts
     assert isinstance(stmts[0], Inhibition)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -10,7 +10,7 @@ from .test_neo4j_client import _get_client
 def test_get_genes_in_tissue():
     # Single query
     client = _get_client()
-    genes = get_genes_in_tissue(client, ("UBERON", "UBERON:0002349"))
+    genes = get_genes_in_tissue(("UBERON", "UBERON:0002349"), client=client)
     assert genes
     node0 = genes[0]
     assert isinstance(node0, Node)
@@ -22,7 +22,7 @@ def test_get_genes_in_tissue():
 def test_get_tissues_for_gene():
     # Single query
     client = _get_client()
-    tissues = get_tissues_for_gene(client, ("HGNC", "9896"))
+    tissues = get_tissues_for_gene(("HGNC", "9896"), client=client)
     assert tissues
     node0 = tissues[0]
     assert isinstance(node0, Node)
@@ -35,14 +35,14 @@ def test_is_gene_in_tissue():
     client = _get_client()
     gene = ("HGNC", "9896")  # RBM10
     tissue = ("UBERON", "UBERON:0035841")  # esophagogastric junction muscularis propria
-    assert is_gene_in_tissue(client, gene, tissue)
+    assert is_gene_in_tissue(gene, tissue, client=client)
 
 
 @pytest.mark.nonpublic
 def test_get_go_terms_for_gene():
     client = _get_client()
     gene = ("HGNC", "2697")  # DBP
-    go_terms = get_go_terms_for_gene(client, gene)
+    go_terms = get_go_terms_for_gene(gene, client=client)
     assert go_terms
     node0 = go_terms[0]
     assert isinstance(node0, Node)
@@ -55,7 +55,7 @@ def test_get_genes_for_go_term():
     # Single query
     client = _get_client()
     go_term = ("GO", "GO:0000978")
-    genes = get_genes_for_go_term(client, go_term)
+    genes = get_genes_for_go_term(go_term, client=client)
     assert genes
     node0 = genes[0]
     assert isinstance(node0, Node)
@@ -69,14 +69,14 @@ def test_is_go_term_for_gene():
     client = _get_client()
     go_term = ("GO", "GO:0000978")
     gene = ("HGNC", "2697")  # DBP
-    assert is_go_term_for_gene(client, gene, go_term)
+    assert is_go_term_for_gene(gene, go_term, client=client)
 
 
 @pytest.mark.nonpublic
 def test_get_trials_for_drug():
     client = _get_client()
     drug = ("CHEBI", "CHEBI:27690")
-    trials = get_trials_for_drug(client, drug)
+    trials = get_trials_for_drug(drug, client=client)
     assert trials
     assert isinstance(trials[0], Node)
     assert trials[0].db_ns == "CLINICALTRIALS"
@@ -87,7 +87,7 @@ def test_get_trials_for_drug():
 def test_get_trials_for_disease():
     client = _get_client()
     disease = ("MESH", "D007855")
-    trials = get_trials_for_disease(client, disease)
+    trials = get_trials_for_disease(disease, client=client)
     assert trials
     assert isinstance(trials[0], Node)
     assert trials[0].db_ns == "CLINICALTRIALS"
@@ -98,7 +98,7 @@ def test_get_trials_for_disease():
 def test_get_drugs_for_trial():
     client = _get_client()
     trial = ("CLINICALTRIALS", "NCT00000114")
-    drugs = get_drugs_for_trial(client, trial)
+    drugs = get_drugs_for_trial(trial, client=client)
     assert drugs
     assert drugs[0].db_ns in ["CHEBI", "MESH"]
     assert ("MESH", "D014810") in {d.grounding() for d in drugs}
@@ -108,7 +108,7 @@ def test_get_drugs_for_trial():
 def test_get_diseases_for_trial():
     client = _get_client()
     trial = ("CLINICALTRIALS", "NCT00000114")
-    diseases = get_diseases_for_trial(client, trial)
+    diseases = get_diseases_for_trial(trial, client=client)
     assert diseases
     assert isinstance(diseases[0], Node)
     assert diseases[0].db_ns == "MESH"
@@ -119,7 +119,7 @@ def test_get_diseases_for_trial():
 def test_get_pathways_for_gene():
     client = _get_client()
     gene = ("HGNC", "16812")
-    pathways = get_pathways_for_gene(client, gene)
+    pathways = get_pathways_for_gene(gene, client=client)
     assert pathways
     assert isinstance(pathways[0], Node)
     assert pathways[0].db_ns in {"WIKIPATHWAYS", "REACTOME"}
@@ -130,7 +130,7 @@ def test_get_pathways_for_gene():
 def test_get_genes_for_pathway():
     client = _get_client()
     pathway = ("WIKIPATHWAYS", "WP5037")
-    genes = get_genes_for_pathway(client, pathway)
+    genes = get_genes_for_pathway(pathway, client=client)
     assert genes
     assert isinstance(genes[0], Node)
     assert genes[0].db_ns == "HGNC"
@@ -142,14 +142,14 @@ def test_is_gene_in_pathway():
     client = _get_client()
     gene = ("HGNC", "16812")
     pathway = ("WIKIPATHWAYS", "WP5037")
-    assert is_gene_in_pathway(client, gene, pathway)
+    assert is_gene_in_pathway(gene, pathway, client=client)
 
 
 @pytest.mark.nonpublic
 def test_get_side_effects_for_drug():
     client = _get_client()
     drug = ("CHEBI", "CHEBI:29108")
-    side_effects = get_side_effects_for_drug(client, drug)
+    side_effects = get_side_effects_for_drug(drug, client=client)
     assert side_effects
     assert isinstance(side_effects[0], Node)
     assert side_effects[0].db_ns in ["GO", "UMLS", "MESH", "HP"]
@@ -160,7 +160,7 @@ def test_get_side_effects_for_drug():
 def test_get_drugs_for_side_effect():
     client = _get_client()
     side_effect = ("UMLS", "C3267206")
-    drugs = get_drugs_for_side_effect(client, side_effect)
+    drugs = get_drugs_for_side_effect(side_effect, client=client)
     assert drugs
     assert isinstance(drugs[0], Node)
     assert drugs[0].db_ns in ["CHEBI", "MESH"]
@@ -172,14 +172,14 @@ def test_is_side_effect_for_drug():
     client = _get_client()
     drug = ("CHEBI", "CHEBI:29108")
     side_effect = ("UMLS", "C3267206")
-    assert is_side_effect_for_drug(client, drug, side_effect)
+    assert is_side_effect_for_drug(drug, side_effect, client=client)
 
 
 @pytest.mark.nonpublic
 def test_get_ontology_child_terms():
     client = _get_client()
     term = ("MESH", "D007855")
-    children = get_ontology_child_terms(client, term)
+    children = get_ontology_child_terms(term, client=client)
     assert children
     assert isinstance(children[0], Node)
     assert children[0].db_ns == "MESH"
@@ -190,7 +190,7 @@ def test_get_ontology_child_terms():
 def test_get_ontology_parent_terms():
     client = _get_client()
     term = ("MESH", "D020263")
-    parents = get_ontology_parent_terms(client, term)
+    parents = get_ontology_parent_terms(term, client=client)
     assert parents
     assert isinstance(parents[0], Node)
     assert parents[0].db_ns == "MESH"
@@ -202,7 +202,7 @@ def test_isa_or_partof():
     client = _get_client()
     term = ("MESH", "D020263")
     parent = ("MESH", "D007855")
-    assert isa_or_partof(client, term, parent)
+    assert isa_or_partof(term, parent, client=client)
 
 
 @pytest.mark.nonpublic


### PR DESCRIPTION
This PR implements the `autoclient` decorator, whose job is to make various INDRA CoGEx query functions more user-friendly (e.g., in a one-off Jupyter notebook scenario). Functions that take in a `client` (regardless of their other inputs and return types) can be annotated with the autoclient in 2 steps:

1. Make sure the `client` is keyword only (i.e., comes after the `*`) and does NOT have a default value
2. Apply autoclient as a decorator like in 
   ```python
    @autoclient()
    def get_tissues_for_gene(gene: Tuple[str, str], *, client: Neo4jClient):
        return client.get_targets(
            gene,
            relation="expressed_in",
            source_type="BioEntity",
            target_type="BioEntity",
        )
   ```

If you're in an interactive environment, it's now possible to do the following:

```python
from indra_cogex.client.queries import get_node_counter

node_counter = get_node_counter()
print(node_counter.most_common())
```

Functions annotated with `autoclient` can be called without the `client` argument and the decorator automagically makes one for the lifetime of the function call. The decorator is also smart enough to close the Neo4j session after it's done so we don't get any issues with hanging connections / exhausted connection pools.

## TODO

- [x] Implement `autoclient` decorator so query functions can be called without a client (one gets transitively made for the time of the function call)
- [x] Add caching flag to autoclient decorator to reduce complexity with lru_cache
- [x] Automatic closing of the connection, even on error
- [x] Apply `autoclient` to many functions (but not all - I only modified functions I've written, for now) 