### PR TITLE
Evidence Count and Belief Filters

### DIFF
--- a/src/indra_cogex/apps/gla/__init__.py
+++ b/src/indra_cogex/apps/gla/__init__.py
@@ -79,6 +79,16 @@ negative_genes_field = TextAreaField(
     validators=[DataRequired()],
 )
 indra_path_analysis_field = BooleanField("Include INDRA path-based analysis (slow)")
+minimum_evidence_field = IntegerField(
+    "Minimum Evidence Count",
+    default=1,
+    description="The minimum number of evidences, if using INDRA path-based analysis.",
+)
+minimum_belief_field = FloatField(
+    "Minimum Belief",
+    default=0.0,
+    description="The minimum belief score, if using INDRA path-based analysis.",
+)
 keep_insignificant_field = BooleanField(
     "Keep insignificant results (leads to long results lists)"
 )
@@ -170,6 +180,8 @@ class DiscreteForm(FlaskForm):
 
     genes = genes_field
     indra_path_analysis = indra_path_analysis_field
+    minimum_evidence = minimum_evidence_field
+    minimum_belief = minimum_belief_field
     alpha = alpha_field
     correction = correction_field
     keep_insignificant = keep_insignificant_field
@@ -185,6 +197,8 @@ class SignedForm(FlaskForm):
 
     positive_genes = positive_genes_field
     negative_genes = negative_genes_field
+    minimum_evidence = minimum_evidence_field
+    minimum_belief = minimum_belief_field
     alpha = alpha_field
     # correction = correction_field
     keep_insignificant = keep_insignificant_field
@@ -207,6 +221,9 @@ class ContinuousForm(FlaskForm):
     permutations = permutations_field
     alpha = alpha_field
     keep_insignificant = keep_insignificant_field
+    source = source_field
+    minimum_evidence = minimum_evidence_field
+    minimum_belief = minimum_belief_field
     submit = SubmitField("Submit")
 
     def get_scores(self) -> Dict[str, float]:
@@ -233,6 +250,8 @@ def discretize_analysis():
         method = form.correction.data
         alpha = form.alpha.data
         keep_insignificant = form.keep_insignificant.data
+        minimum_evidence_count = form.minimum_evidence.data
+        minimum_belief = form.minimum_belief.data
         genes, errors = form.parse_genes()
         gene_set = set(genes)
 
@@ -264,6 +283,8 @@ def discretize_analysis():
                 method=method,
                 alpha=alpha,
                 keep_insignificant=keep_insignificant,
+                minimum_evidence_count=minimum_evidence_count,
+                minimum_belief=minimum_belief,
             )
             indra_downstream_results = indra_downstream_ora(
                 client,
@@ -271,6 +292,8 @@ def discretize_analysis():
                 method=method,
                 alpha=alpha,
                 keep_insignificant=keep_insignificant,
+                minimum_evidence_count=minimum_evidence_count,
+                minimum_belief=minimum_belief,
             )
         else:
             indra_upstream_results = None
@@ -311,6 +334,8 @@ def signed_analysis():
             negative_hgnc_ids=negative_genes,
             alpha=form.alpha.data,
             keep_insignificant=form.keep_insignificant.data,
+            minimum_evidence_count=form.minimum_evidence.data,
+            minimum_belief=form.minimum_belief.data,
         )
         return flask.render_template(
             "signed_results.html",
@@ -371,6 +396,8 @@ def continuous_analysis():
                 permutation_num=permutations,
                 alpha=alpha,
                 keep_insignificant=keep_insignificant,
+                minimum_evidence_count=form.minimum_evidence.data,
+                minimum_belief=form.minimum_belief.data,
             )
         elif source == "indra-downstream":
             results = indra_downstream_gsea(
@@ -379,6 +406,8 @@ def continuous_analysis():
                 permutation_num=permutations,
                 alpha=alpha,
                 keep_insignificant=keep_insignificant,
+                minimum_evidence_count=form.minimum_evidence.data,
+                minimum_belief=form.minimum_belief.data,
             )
         else:
             raise ValueError

--- a/src/indra_cogex/apps/gla/templates/continuous_results.html
+++ b/src/indra_cogex/apps/gla/templates/continuous_results.html
@@ -19,7 +19,7 @@
     <script>
         const datatablesConf = {"order": [[2, "asc"]]};
         $(document).ready(function () {
-            $("#table-go").DataTable(datatablesConf);
+            $("#table-continuous").DataTable(datatablesConf);
         });
     </script>
 {% endblock %}
@@ -55,15 +55,25 @@
     <div class="card card-body bg-light">
         <h1 class="display-3">Continuous Gene Set Analysis</h1>
         <div>
-            <h3>GO Results</h3>
+            <h3>Results</h3>
             <div>
                 <p>
-                    These results are acquired by running GSEA on the genes annotated to terms in the
+                    These results are acquired by running GSEA on the genes annotated to terms in
+                    {% if source == "go" %}the
                     <a href="http://geneontology.org/docs/go-annotations/">Gene Ontology</a>
                     via the <a href="http://geneontology.org/docs/go-annotations/">Gene
                     Ontology Annotations Database</a>.
+                    {% elif source == "wikipathways" %}
+                        WikiPathways.
+                    {% elif source == "reactome" %}
+                        Reactome.
+                    {% elif source == "indra-upstream" %}
+                        INDRA upstream controllers.
+                    {% elif source == "indra-downstream" %}
+                        INDRA downstream regulators.
+                    {% endif %}
                 </p>
-                {{ render_table(go_results, "table-go") }}
+                {{ render_table(results, "table-continuous") }}
             </div>
         </div>
     </div>

--- a/src/indra_cogex/client/enrichment/continuous.py
+++ b/src/indra_cogex/client/enrichment/continuous.py
@@ -224,6 +224,8 @@ def indra_upstream_gsea(
     directory: Union[None, Path, str] = None,
     *,
     client: Neo4jClient,
+    minimum_evidence_count: Optional[int] = None,
+    minimum_belief: Optional[float] = None,
     **kwargs,
 ) -> pd.DataFrame:
     """Run GSEA for each entry in the INDRA database and the set
@@ -239,6 +241,12 @@ def indra_upstream_gsea(
     directory :
         Specify the directory if the results should be saved, including
         both a dataframe and plots for each gen set
+    minimum_evidence_count :
+        The minimum number of evidences for a relationship to count it as a regulator.
+        Defaults to 1 (i.e., cutoff not applied.
+    minimum_belief :
+        The minimum belief for a relationship to count it as a regulator.
+        Defaults to 0.0 (i.e., cutoff not applied).
     kwargs :
         Remaining keyword arguments to pass through to :func:`gseapy.prerank
 
@@ -248,7 +256,11 @@ def indra_upstream_gsea(
         A pandas dataframe with the GSEA results
     """
     return gsea(
-        gene_sets=get_entity_to_targets(client=client),
+        gene_sets=get_entity_to_targets(
+            client=client,
+            minimum_evidence_count=minimum_evidence_count,
+            minimum_belief=minimum_belief,
+        ),
         scores=scores,
         directory=directory,
         **kwargs,
@@ -261,6 +273,8 @@ def indra_downstream_gsea(
     directory: Union[None, Path, str] = None,
     *,
     client: Neo4jClient,
+    minimum_evidence_count: Optional[int] = None,
+    minimum_belief: Optional[float] = None,
     **kwargs,
 ) -> pd.DataFrame:
     """Run GSEA for each entry in the INDRA database and the set
@@ -276,6 +290,12 @@ def indra_downstream_gsea(
     directory :
         Specify the directory if the results should be saved, including
         both a dataframe and plots for each gen set
+    minimum_evidence_count :
+        The minimum number of evidences for a relationship to count it as a regulator.
+        Defaults to 1 (i.e., cutoff not applied.
+    minimum_belief :
+        The minimum belief for a relationship to count it as a regulator.
+        Defaults to 0.0 (i.e., cutoff not applied).
     kwargs :
         Remaining keyword arguments to pass through to :func:`gseapy.prerank
 
@@ -285,7 +305,11 @@ def indra_downstream_gsea(
         A pandas dataframe with the GSEA results
     """
     return gsea(
-        gene_sets=get_entity_to_regulators(client=client),
+        gene_sets=get_entity_to_regulators(
+            client=client,
+            minimum_evidence_count=minimum_evidence_count,
+            minimum_belief=minimum_belief,
+        ),
         scores=scores,
         directory=directory,
         **kwargs,

--- a/src/indra_cogex/client/enrichment/discrete.py
+++ b/src/indra_cogex/client/enrichment/discrete.py
@@ -178,7 +178,12 @@ def reactome_ora(
 
 
 def indra_downstream_ora(
-    client: Neo4jClient, gene_ids: Iterable[str], **kwargs
+    client: Neo4jClient,
+    gene_ids: Iterable[str],
+    *,
+    minimum_evidence_count: Optional[int] = None,
+    minimum_belief: Optional[float] = None,
+    **kwargs,
 ) -> pd.DataFrame:
     """
     Calculate a p-value for each entity in the INDRA database
@@ -187,7 +192,11 @@ def indra_downstream_ora(
     """
     count = count_human_genes(client=client)
     return _do_ora(
-        get_entity_to_regulators(client=client),
+        get_entity_to_regulators(
+            client=client,
+            minimum_evidence_count=minimum_evidence_count,
+            minimum_belief=minimum_belief,
+        ),
         gene_ids=gene_ids,
         count=count,
         **kwargs,
@@ -195,7 +204,12 @@ def indra_downstream_ora(
 
 
 def indra_upstream_ora(
-    client: Neo4jClient, gene_ids: Iterable[str], **kwargs
+    client: Neo4jClient,
+    gene_ids: Iterable[str],
+    *,
+    minimum_evidence_count: Optional[int] = None,
+    minimum_belief: Optional[float] = None,
+    **kwargs,
 ) -> pd.DataFrame:
     """
     Calculate a p-value for each entity in the INDRA database
@@ -204,7 +218,14 @@ def indra_upstream_ora(
     """
     count = count_human_genes(client=client)
     return _do_ora(
-        get_entity_to_targets(client=client), gene_ids=gene_ids, count=count, **kwargs
+        get_entity_to_targets(
+            client=client,
+            minimum_evidence_count=minimum_evidence_count,
+            minimum_belief=minimum_belief,
+        ),
+        gene_ids=gene_ids,
+        count=count,
+        **kwargs,
     )
 
 


### PR DESCRIPTION
This PR was originally the implementation of the weighted ORA but I did a couple other things that need less work so I've renamed this PR for it. This PR does the following:

1. Enable choosing which dataset you want (e.g., GO, Reactome WikiPathways, INDRA-upstream, INDRA-downstream) in the continuous GSEA page
2. Add minimum evidence count field to all three analyses
3. Add minimum belief field to all three analyses