### PR TITLE
Fix index building call for relationship indexes

### DIFF
--- a/src/indra_cogex/indexing/__init__.py
+++ b/src/indra_cogex/indexing/__init__.py
@@ -30,6 +30,6 @@ def index_indra_rel_on_stmt_hash(client: Neo4jClient):
     client :
         Neo4jClient instance to the graph database to be indexed
     """
-    client.create_single_property_node_index(
-        index_name="indra_rel_hash", label="indra_rel", property_name="stmt_hash"
+    client.create_single_property_relationship_index(
+        index_name="indra_rel_hash", rel_type="indra_rel", property_name="stmt_hash"
     )

--- a/src/indra_cogex/indexing/cli.py
+++ b/src/indra_cogex/indexing/cli.py
@@ -41,10 +41,12 @@ def main(
     client = _get_client(url, auth)
     if all_ or index_evidence_nodes:
         from . import index_evidence_on_stmt_hash
+
         click.secho("Indexing Evidence nodes on the stmt_hash property.", fg="green")
         index_evidence_on_stmt_hash(client, exist_ok=exist_ok)
     if all_ or index_indra_relations:
         from . import index_indra_rel_on_stmt_hash
+
         click.secho("Indexing INDRA relations on the stmt_hash property.", fg="green")
         index_indra_rel_on_stmt_hash(client)
     click.secho("Started all requested indexing.", fg="green")


### PR DESCRIPTION
This PR fixes a bug where the wrong method on the client was called for relationship index building. The correct method to call is `Neo4jClient.create_single_property_relationship_index`.