### PR TITLE
Add HGNC-enzyme source

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,21 @@ non-causal contextual relations including properties, ontology, and data.
 
 ![A summary of the content in INDRA CoGEx](img/summary.png)
 
-| Knowledge source    | Relation            | Description                                                                                                       |
-|---------------------|-----------------|-------------------------------------------------------------------------------------------------------------------|
-| [INDRA](indra.bio)               | indra_rel       | The source regulates or interacts with the target according to an INDRA Statement.                         |
-| [INDRA Ontology](indra.bio)      | isa / partof             | The source node is a subclass or part of the target node.                                                     |
-| [Gene Ontology](http://geneontology.org/)       | associated_with | The gene represented by the source is associated with the GO term represented by the target.             |
-| [BGee](https://bgee.org/)                | expressed_in    | The gene represented by the source is expressed in the tissue/cell type represented by the target.                |
+| Knowledge source                                                    | Relation                            | Description                                                                                                                    |
+|---------------------------------------------------------------------|-------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| [INDRA](indra.bio)                                                  | indra_rel                           | The source regulates or interacts with the target according to an INDRA Statement.                                             |
+| [INDRA Ontology](indra.bio)                                         | isa / partof                        | The source node is a subclass or part of the target node.                                                                      |
+| [Gene Ontology](http://geneontology.org/)                           | associated_with                     | The gene represented by the source is associated with the GO term represented by the target.                                   |
+| [BGee](https://bgee.org/)                                           | expressed_in                        | The gene represented by the source is expressed in the tissue/cell type represented by the target.                             |
 | [CCLE](https://www.cbioportal.org/study/summary?id=ccle_broad_2019) | mutated_in / copy_number_altered_in | The gene represented by the source is mutated or its copy number is altered in the cancer cell line represented by the target. |
-| [CCLE](https://www.cbioportal.org/study/summary?id=ccle_broad_2019) | sensitive_to | The cancer cell line represented by the source is sensitive to the drug represented by the target. |
-| [ClinicalTrials.gov](https://clinicaltrials.gov/) | tested_in | The drug represented by the source is tested in the clinical trial represented by the target. |
-| [ClinicalTrials.gov](https://clinicaltrials.gov/) | has_trial | The disease/condition represented by the source has a clinical trial represented by the target. |
-| [ChEMBL](https://www.ebi.ac.uk/chembl/)              | has_indication  | The chemical represented by the source has been studied for use against the indication represented by the target. |
-| [SIDER](http://sideeffects.embl.de/)               | has_side_effect | The chemical represented by the source has a side effect represented by the target. |
-| [Reactome](https://reactome.org/)            | haspart         | The pathway represented by the source node contains the gene represented by the target node.                       |
-| [WikiPathways](https://www.wikipathways.org/)        | haspart         | The pathway represented by the source node contains the gene represented by the target node.                       |
-
+| [CCLE](https://www.cbioportal.org/study/summary?id=ccle_broad_2019) | sensitive_to                        | The cancer cell line represented by the source is sensitive to the drug represented by the target.                             |
+| [ClinicalTrials.gov](https://clinicaltrials.gov/)                   | tested_in                           | The drug represented by the source is tested in the clinical trial represented by the target.                                  |
+| [ClinicalTrials.gov](https://clinicaltrials.gov/)                   | has_trial                           | The disease/condition represented by the source has a clinical trial represented by the target.                                |
+| [ChEMBL](https://www.ebi.ac.uk/chembl/)                             | has_indication                      | The chemical represented by the source has been studied for use against the indication represented by the target.              |
+| [SIDER](http://sideeffects.embl.de/)                                | has_side_effect                     | The chemical represented by the source has a side effect represented by the target.                                            |
+| [Reactome](https://reactome.org/)                                   | haspart                             | The pathway represented by the source node contains the gene represented by the target node.                                   |
+| [WikiPathways](https://www.wikipathways.org/)                       | haspart                             | The pathway represented by the source node contains the gene represented by the target node.                                   |
+| [Enzyme Codes](https://www.ebi.ac.uk/intenz/)                       | has_activity                        | The relation between a gene and its enzyme class(es).                                                                          |
 
 ## Installation
 

--- a/src/indra_cogex/sources/ec/__init__.py
+++ b/src/indra_cogex/sources/ec/__init__.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+"""Processor for enzyme codes."""
+
+from typing import Iterable
+
+import pyobo
+from indra.databases import hgnc_client
+from indra.databases.hgnc_client import enzyme_to_hgncs, hgnc_to_enzymes
+
+from indra_cogex.representation import Node, Relation
+from indra_cogex.sources import Processor
+
+__all__ = [
+    "HGNCEnzymeProcessor",
+]
+
+
+class HGNCEnzymeProcessor(Processor):
+    """A processor for HGNC enzyme annotations."""
+
+    name = "hgnc_enzymes"
+    node_types = ["BioEntity"]
+
+    def __init__(self):
+        self.genes = {
+            hgnc_id: Node.standardized(
+                db_ns="hgnc", db_id=hgnc_id, name=hgnc_client.get_hgnc_name(hgnc_id), labels=["BioEntity"]
+            )
+            for hgnc_id in hgnc_to_enzymes
+        }
+        self.enzymes = {
+            enzyme_id: Node.standardized(
+                db_ns="ec-code", db_id=enzyme_id, name=pyobo.get_name("ec-code", enzyme_id), labels=["BioEntity"]
+            )
+            for enzyme_id in enzyme_to_hgncs
+        }
+
+    def get_nodes(self) -> Iterable[Node]:
+        """Iterate over HGNC genes and enzymes."""
+        yield from self.genes.values()
+        yield from self.enzymes.values()
+
+    def get_relations(self) -> Iterable[Relation]:
+        """Iterate over HGNC's enzyme annotations."""
+        for hgnc_id, enzyme_ids in hgnc_to_enzymes.items():
+            for enzyme_id in enzyme_ids:
+                gene = self.genes[hgnc_id]
+                enzyme = self.enzymes[enzyme_id]
+                yield Relation(
+                    gene.db_ns,
+                    gene.db_id,
+                    enzyme.db_ns,
+                    enzyme.db_id,
+                    "has_activity",
+                    dict(source=self.name),
+                )
+
+
+if __name__ == '__main__':
+    HGNCEnzymeProcessor.cli()

--- a/src/indra_cogex/sources/ec/__main__.py
+++ b/src/indra_cogex/sources/ec/__main__.py
@@ -1,0 +1,6 @@
+"""Run the enzyme code processor using ``python -m indra_cogex.sources.ec``."""
+
+from . import HGNCEnzymeProcessor
+
+if __name__ == "__main__":
+    HGNCEnzymeProcessor.cli()


### PR DESCRIPTION
This PR adds a new source that connects human genes to their enzyme classes via HGNC's annotations as a follow-up to https://github.com/sorgerlab/indra/pull/1367.

Potential TODOs:

- [x] Handle mappings between genes and classes (i.e., EC codes that take the form `X.Y` or `X.Y.Z`)
- [ ] GO (i.e., molecular activity terms) to EC code equivalence (http://release.geneontology.org/2022-01-13/ontology/external2go/ec2go)