### PR TITLE
Fix query tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install tox
+          echo "PYTHONPATH=${PYTHONPATH}"
           # Get INDRA Bioontology
           BIOONTOLOGY_VERSION=$(python -m indra.ontology.bio version)
           echo $BIOONTOLOGY_VERSION

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,13 @@ jobs:
         run:
           echo $PYTEST_ADDOPTS
       - name: Install dependencies
-        run: pip install tox
+        run: |
+          pip install tox
+          # Get INDRA Bioontology
+          BIOONTOLOGY_VERSION=$(python -m indra.ontology.bio version)
+          echo $BIOONTOLOGY_VERSION
+          mkdir -p $HOME/.indra/bio_ontology/$BIOONTOLOGY_VERSION
+          wget -nv https://bigmech.s3.amazonaws.com/travis/bio_ontology/$BIOONTOLOGY_VERSION/mock_ontology.pkl -O $HOME/.indra/bio_ontology/$BIOONTOLOGY_VERSION/bio_ontology.pkl
       - name: Test with pytest
         run:
           tox -e py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,10 +26,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install tox
-          echo "PYTHONPATH=${PYTHONPATH}"
-          # Get INDRA Bioontology
-          BIOONTOLOGY_VERSION=$(python -m indra.ontology.bio version)
-          echo $BIOONTOLOGY_VERSION
+          BIOONTOLOGY_VERSION=1.22
+          echo "bio ontology version: ${BIOONTOLOGY_VERSION}"
           mkdir -p $HOME/.indra/bio_ontology/$BIOONTOLOGY_VERSION
           wget -nv https://bigmech.s3.amazonaws.com/travis/bio_ontology/$BIOONTOLOGY_VERSION/mock_ontology.pkl -O $HOME/.indra/bio_ontology/$BIOONTOLOGY_VERSION/bio_ontology.pkl
       - name: Test with pytest

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -740,7 +740,7 @@ def get_evidences_for_mesh(
 
 @autoclient()
 def get_evidences_for_stmt_hash(
-    stmt_hash: Union[str, int], *, client: Neo4jClient
+    stmt_hash: int, *, client: Neo4jClient
 ) -> Iterable[Evidence]:
     """Return the matching evidence objects for the given statement hash.
 
@@ -757,7 +757,7 @@ def get_evidences_for_stmt_hash(
         The evidence objects for the given statement hash.
     """
     query = (
-        """MATCH (n:Evidence {stmt_hash: "%s"})
+        """MATCH (n:Evidence {stmt_hash: %s})
                RETURN n.evidence"""
         % stmt_hash
     )

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -794,7 +794,7 @@ def get_evidences_for_stmt_hashes(
         A mapping of stmt hash to a list of evidence objects for the given
         statement hashes.
     """
-    stmt_hashes_str = ",".join(f"{h}" for h in stmt_hashes)
+    stmt_hashes_str = ",".join(str(h) for h in stmt_hashes)
     query = (
         """
         MATCH (n:Evidence)

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -693,7 +693,7 @@ def get_mesh_ids_for_pmid(
 @autoclient()
 def get_evidences_for_mesh(
     mesh_term: Tuple[str, str], include_child_terms: bool = True, *, client: Neo4jClient
-) -> Dict[str, List[Evidence]]:
+) -> Dict[int, List[Evidence]]:
     """Return the evidence objects for the given MESH term.
 
     Parameters
@@ -767,8 +767,8 @@ def get_evidences_for_stmt_hash(
 
 @autoclient()
 def get_evidences_for_stmt_hashes(
-    stmt_hashes: Iterable[Union[str, int]], *, client: Neo4jClient
-) -> Dict[str, List[Evidence]]:
+    stmt_hashes: Iterable[int], *, client: Neo4jClient
+) -> Dict[int, List[Evidence]]:
     """Return the matching evidence objects for the given statement hashes.
 
     Parameters
@@ -817,14 +817,13 @@ def get_stmts_for_pmid(
     """
     # Todo: Investigate if it's possible to do this in one query like
     # MATCH (e:Evidence)-[:has_citation]->(:Publication {id: "pubmed:14898026"})
-    # MATCH (:BioEntity)-[r:indra_rel {stmt_hash: toInteger(e.stmt_hash)}]->(:BioEntity)
+    # MATCH (:BioEntity)-[r:indra_rel {stmt_hash: e.stmt_hash}]->(:BioEntity)
     # RETURN r, e
-    # note that the hash str/int conversion is done as part of the query.
 
     # Todo: Add filters: e.g. belief cutoff, sources, db supported only,
     #  stmt type
     pmid_norm = norm_id(*pmid_term)
-    # First, get the hashes and evidences for the given PubMed ID
+    # Get the hashes and evidences for the given PubMed ID
     hash_query = (
         """
         MATCH (e:Evidence)-[:has_citation]->(:Publication {id: "%s"})
@@ -865,8 +864,8 @@ def get_stmts_for_mesh(
 
 @autoclient()
 def get_stmts_for_stmt_hashes(
-    stmt_hashes: Iterable[str],
-    evidence_map: Optional[Dict[str, List[Evidence]]] = None,
+    stmt_hashes: Iterable[int],
+    evidence_map: Optional[Dict[int, List[Evidence]]] = None,
     *,
     client: Neo4jClient,
 ) -> Iterable[Statement]:
@@ -886,9 +885,7 @@ def get_stmts_for_stmt_hashes(
     :
         The statements for the given statement hashes.
     """
-    stmt_hashes_str = ",".join(stmt_hashes)
-    # NOTE: for indra_rel Relationships, stmt_hash is an int, in Evidence
-    # nodes stmt_hash is a string
+    stmt_hashes_str = ",".join(str(h) for h in stmt_hashes)
     stmts_query = (
         """
         MATCH p=(:BioEntity)-[r:indra_rel]->(:BioEntity)
@@ -898,7 +895,7 @@ def get_stmts_for_stmt_hashes(
         % stmt_hashes_str
     )
     rels = [client.neo4j_to_relation(r[0]) for r in client.query_tx(stmts_query)]
-    stmts = {str(s.get_hash()): s for s in indra_stmts_from_relations(rels)}
+    stmts: Dict[int, Statement] = {s.get_hash(): s for s in indra_stmts_from_relations(rels)}
 
     # If the evidence_map is provided, check if it covers all the hashes
     # and if not, query for the evidence objects
@@ -961,8 +958,8 @@ def _get_mesh_child_terms(
 
 
 def _get_ev_dict_from_hash_ev_query(
-    result: Optional[Iterable[List[str]]] = None,
-) -> Dict[str, List[Evidence]]:
+    result: Optional[Iterable[List[Union[int, str]]]] = None,
+) -> Dict[int, List[Evidence]]:
     """Assumes `result` is an Iterable of pairs of [hash, evidence_json]"""
     if result is None:
         logger.warning("No result for hash, Evidence query, returning empty dict")

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -558,7 +558,12 @@ def get_ontology_child_terms(
     :
         The child terms of the given term.
     """
-    return client.get_predecessors(term, relations={"isa", "partof"})
+    return client.get_predecessors(
+        term,
+        relations={"isa", "partof"},
+        source_type="BioEntity",
+        target_type="BioEntity",
+    )
 
 
 @autoclient()
@@ -579,7 +584,12 @@ def get_ontology_parent_terms(
     :
         The parent terms of the given term.
     """
-    return client.get_successors(term, relations={"isa", "partof"})
+    return client.get_successors(
+        term,
+        relations={"isa", "partof"},
+        source_type="BioEntity",
+        target_type="BioEntity",
+    )
 
 
 @autoclient()

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -794,7 +794,7 @@ def get_evidences_for_stmt_hashes(
         A mapping of stmt hash to a list of evidence objects for the given
         statement hashes.
     """
-    stmt_hashes_str = ",".join(f'{h}' for h in stmt_hashes)
+    stmt_hashes_str = ",".join(f"{h}" for h in stmt_hashes)
     query = (
         """
         MATCH (n:Evidence)
@@ -905,7 +905,9 @@ def get_stmts_for_stmt_hashes(
         % stmt_hashes_str
     )
     rels = [client.neo4j_to_relation(r[0]) for r in client.query_tx(stmts_query)]
-    stmts: Dict[int, Statement] = {s.get_hash(): s for s in indra_stmts_from_relations(rels)}
+    stmts: Dict[int, Statement] = {
+        s.get_hash(): s for s in indra_stmts_from_relations(rels)
+    }
 
     # If the evidence_map is provided, check if it covers all the hashes
     # and if not, query for the evidence objects

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -784,7 +784,7 @@ def get_evidences_for_stmt_hashes(
         A mapping of stmt hash to a list of evidence objects for the given
         statement hashes.
     """
-    stmt_hashes_str = ",".join(f'"{h}"' for h in stmt_hashes)
+    stmt_hashes_str = ",".join(f'{h}' for h in stmt_hashes)
     query = (
         """
         MATCH (n:Evidence)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -254,7 +254,7 @@ def test_get_evidence_obj_for_mesh_id():
 def test_get_evidence_obj_for_stmt_hash():
     # Note: This statement has 3 evidences
     # Single query
-    stmt_hash = "12198579805553967"
+    stmt_hash = 12198579805553967
     client = _get_client()
     ev_objs = get_evidences_for_stmt_hash(stmt_hash, client=client)
     assert ev_objs
@@ -265,15 +265,15 @@ def test_get_evidence_obj_for_stmt_hash():
 def test_get_evidence_obj_for_stmt_hashes():
     # Note: These statements have 3+5 evidences
     # Single query
-    stmt_hashes = ["12198579805553967", "30651649296901235"]
+    stmt_hashes = [12198579805553967, 30651649296901235]
     client = _get_client()
     ev_dict = get_evidences_for_stmt_hashes(stmt_hashes, client=client)
     assert ev_dict
-    assert set(ev_dict.keys()) == {"12198579805553967", "30651649296901235"}
-    assert ev_dict["12198579805553967"]
-    assert ev_dict["30651649296901235"]
-    assert isinstance(ev_dict["12198579805553967"][0], Evidence)
-    assert isinstance(ev_dict["30651649296901235"][0], Evidence)
+    assert set(ev_dict.keys()) == {12198579805553967, 30651649296901235}
+    assert ev_dict[12198579805553967]
+    assert ev_dict[30651649296901235]
+    assert isinstance(ev_dict[12198579805553967][0], Evidence)
+    assert isinstance(ev_dict[30651649296901235][0], Evidence)
 
 
 @pytest.mark.nonpublic

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,6 +1,7 @@
 import pytest
-from indra_cogex.client.queries import *
 from indra.statements import *
+
+from indra_cogex.client.queries import *
 from indra_cogex.representation import Node
 
 from .test_neo4j_client import _get_client
@@ -290,7 +291,7 @@ def test_get_stmts_for_pmid():
 def test_get_stmts_for_mesh_id_w_children():
     # Two queries:
     # 1. evidences for publications with pmid having mesh annotation
-    # 2. statements for the evidences in 2
+    # 2. statements for the evidences in 1
     client = _get_client()
     mesh_id = ("MESH", "D000068236")
     stmts = get_stmts_for_mesh(mesh_id, client=client)
@@ -302,7 +303,7 @@ def test_get_stmts_for_mesh_id_w_children():
 def test_get_stmts_for_mesh_id_wo_children():
     # Two queries:
     # 1. evidences for publications with pmid having mesh annotation
-    # 2. statements for the evidences in 2
+    # 2. statements for the evidences in 1
     client = _get_client()
     mesh_id = ("MESH", "D000068236")
     stmts = get_stmts_for_mesh(mesh_id, include_child_terms=False, client=client)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -295,7 +295,7 @@ def test_get_stmts_for_mesh_id_w_children():
     mesh_id = ("MESH", "D000068236")
     stmts = get_stmts_for_mesh(mesh_id, client=client)
     assert stmts
-    assert isinstance(stmts[0], Activation)
+    assert isinstance(stmts[0], Inhibition)
 
 
 @pytest.mark.nonpublic
@@ -307,7 +307,7 @@ def test_get_stmts_for_mesh_id_wo_children():
     mesh_id = ("MESH", "D000068236")
     stmts = get_stmts_for_mesh(mesh_id, include_child_terms=False, client=client)
     assert stmts
-    assert isinstance(stmts[0], Activation)
+    assert isinstance(stmts[0], Inhibition)
 
 
 @pytest.mark.nonpublic

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,5 +1,5 @@
 import pytest
-from indra.statements import *
+from indra.statements import Statement, Evidence
 
 from indra_cogex.client.queries import *
 from indra_cogex.representation import Node
@@ -284,7 +284,7 @@ def test_get_stmts_for_pmid():
     pmid = ("PUBMED", "14898026")
     stmts = get_stmts_for_pmid(pmid, client=client)
     assert stmts
-    assert isinstance(stmts[0], Inhibition)
+    assert isinstance(stmts[0], Statement)
 
 
 @pytest.mark.nonpublic
@@ -296,7 +296,7 @@ def test_get_stmts_for_mesh_id_w_children():
     mesh_id = ("MESH", "D000068236")
     stmts = get_stmts_for_mesh(mesh_id, client=client)
     assert stmts
-    assert isinstance(stmts[0], Inhibition)
+    assert isinstance(stmts[0], Statement)
 
 
 @pytest.mark.nonpublic
@@ -308,7 +308,7 @@ def test_get_stmts_for_mesh_id_wo_children():
     mesh_id = ("MESH", "D000068236")
     stmts = get_stmts_for_mesh(mesh_id, include_child_terms=False, client=client)
     assert stmts
-    assert isinstance(stmts[0], Inhibition)
+    assert isinstance(stmts[0], Statement)
 
 
 @pytest.mark.nonpublic
@@ -319,7 +319,7 @@ def test_get_stmts_by_hashes():
     client = _get_client()
     stmts = get_stmts_for_stmt_hashes(stmt_hashes, client=client)
     assert stmts
-    assert isinstance(stmts[0], Inhibition)
+    assert isinstance(stmts[0], Statement)
 
 
 @pytest.mark.nonpublic


### PR DESCRIPTION
This PR updates the query functions in `queries.py` and the query tests in `test_queries.py` to:

- Adapt to that some node and edge properties have switched their field types from string to something else
- Speed up some queries by setting the node type