### PR TITLE
Implement GO curation workflow

### DIFF
--- a/src/indra_cogex/client/__init__.py
+++ b/src/indra_cogex/client/__init__.py
@@ -1,0 +1,5 @@
+"""INDRA CoGEx Client."""
+
+from .neo4j_client import *
+from .queries import *
+from .subnetwork import *

--- a/src/indra_cogex/client/curation.py
+++ b/src/indra_cogex/client/curation.py
@@ -8,7 +8,7 @@ from indra.resources import load_resource_json
 from indra.statements import Statement
 from networkx.algorithms import edge_betweenness_centrality
 
-from .neo4j_client import Neo4jClient
+from .neo4j_client import Neo4jClient, autoclient
 from .subnetwork import indra_subnetwork_go
 
 __all__ = [
@@ -81,6 +81,7 @@ def get_curation_df(stmts: Iterable[Statement]) -> pd.DataFrame:
     return df
 
 
+@autoclient()
 def get_go_curation_hashes(
     go_term: Tuple[str, str],
     *,

--- a/src/indra_cogex/client/curation.py
+++ b/src/indra_cogex/client/curation.py
@@ -80,9 +80,43 @@ def get_go_curation_hashes(
     go_term: Tuple[str, str],
     *,
     client: Neo4jClient,
+    include_indirect: bool = False,
+    mediated: bool = False,
+    upstream_controllers: bool = False,
+    downstream_targets: bool = False,
 ) -> List[int]:
-    """Get prioritized statement hashes to curate for a given GO term."""
-    go_stmts = indra_subnetwork_go(
-        go_term=go_term, client=client, include_indirect=True
+    """Get prioritized statement hashes to curate for a given GO term.
+
+    Parameters
+    ----------
+    go_term :
+        The GO term to query
+    client :
+        The Neo4j client.
+    include_indirect :
+        Should ontological children of the given GO term
+        be queried as well? Defaults to False.
+    mediated:
+        Should relations A->X->B be included for X not associated
+        to the given GO term?
+    upstream_controllers:
+        Should relations A<-X->B be included for upstream controller
+        X not associated to the given GO term?
+    downstream_targets:
+        Should relations A->X<-B be included for downstream target
+        X not associated to the given GO term?
+
+    Returns
+    -------
+    :
+        A list of INDRA statement hashes prioritized for curation
+    """
+    stmts = indra_subnetwork_go(
+        go_term=go_term,
+        client=client,
+        include_indirect=include_indirect,
+        mediated=mediated,
+        upstream_controllers=upstream_controllers,
+        downstream_targets=downstream_targets,
     )
-    return get_prioritized_stmt_hashes(go_stmts)
+    return get_prioritized_stmt_hashes(stmts)

--- a/src/indra_cogex/client/curation.py
+++ b/src/indra_cogex/client/curation.py
@@ -109,7 +109,7 @@ def get_go_curation_hashes(
     Parameters
     ----------
     go_term :
-        The GO term to query
+        The GO term to query. Example: ``("GO", "GO:0006915")``
     client :
         The Neo4j client.
     include_indirect :

--- a/src/indra_cogex/client/curation.py
+++ b/src/indra_cogex/client/curation.py
@@ -17,7 +17,7 @@ __all__ = [
 ]
 
 # TODO can this be imported from INDRA and auto-generated?
-DATABASES = {"biogrid", "hprd", 'signor', 'phosphoelm', 'signor', 'biopax'}
+DATABASES = {"biogrid", "hprd", "signor", "phosphoelm", "signor", "biopax"}
 
 
 def _keep_by_source(source_counts) -> bool:
@@ -82,5 +82,7 @@ def get_go_curation_hashes(
     client: Neo4jClient,
 ) -> List[int]:
     """Get prioritized statement hashes to curate for a given GO term."""
-    go_stmts = indra_subnetwork_go(go_term=go_term, client=client, include_indirect=True)
+    go_stmts = indra_subnetwork_go(
+        go_term=go_term, client=client, include_indirect=True
+    )
     return get_prioritized_stmt_hashes(go_stmts)

--- a/src/indra_cogex/client/curation.py
+++ b/src/indra_cogex/client/curation.py
@@ -1,0 +1,72 @@
+"""Tools for INDRA curation."""
+
+from typing import Iterable, List, Optional
+
+import pandas as pd
+from indra.assemblers.indranet import IndraNetAssembler
+from indra.statements import Statement
+from networkx.algorithms import edge_betweenness_centrality
+
+__all__ = [
+    "get_prioritized_stmt_hashes",
+    "get_curation_df",
+]
+
+# TODO can this be imported from INDRA and auto-generated?
+DATABASES = {"biogrid", "hprd", 'signor', 'phosphoelm', 'signor', 'biopax'}
+
+
+def _keep_by_source(source_counts) -> bool:
+    return all(k not in DATABASES for k in source_counts)
+
+
+def _get_text(stmt: Statement) -> Optional[str]:
+    return stmt.evidence[0].text if stmt.evidence else None
+
+
+def _get_curated_statement_hashes() -> set[int]:
+    return set()  # FIXME implement!
+
+
+def get_prioritized_stmt_hashes(stmts: Iterable[Statement]) -> List[int]:
+    """Get the priority ordered hashes of statements to curate from."""
+    df = get_curation_df(stmts)
+    return list(df["stmt_hash"])
+
+
+def get_curation_df(stmts: Iterable[Statement]) -> pd.DataFrame:
+    """Generate a curation dataframe from INDRA statements."""
+    assembler = IndraNetAssembler(list(stmts))
+
+    # Get centrality measurements that are unaffected by other filters
+    centralities = edge_betweenness_centrality(assembler.make_model())
+
+    # Make the dataframe but include an extra column for text.
+    # This works since the INDRANet assembler currently goes one
+    # evidence per row (i.e., a statement could have many rows)
+    df = assembler.make_df(extra_columns=[("text", _get_text)])
+
+    # Don't worry about curating statements with no text
+    df = df[df.text.notna()]
+
+    # Don't worry about curating statements that are already curated
+    curated_statement_hashes = _get_curated_statement_hashes()
+    df = df[~df["stmt_hash"].isin(curated_statement_hashes)]
+
+    # Don't worry about curating statements
+    # that already have database evidence
+    df = df[df["source_counts"].map(_keep_by_source)]
+
+    # Look up centralities for remaining rows
+    df["centralities"] = [
+        centralities.get((left, right))
+        for left, right in df[["agA_name", "agB_name"]].values
+    ]
+
+    # Sort by the most central edges
+    df = df.sort_values("centralities", ascending=False)
+
+    # If several evidences from the same statement, dont need
+    # to have the hash multiple times
+    df = df.drop_duplicates("stmt_hash")
+    return df

--- a/src/indra_cogex/client/curation.py
+++ b/src/indra_cogex/client/curation.py
@@ -1,9 +1,10 @@
 """Tools for INDRA curation."""
 
-from typing import Iterable, List, Optional, Tuple
+from typing import Iterable, List, Optional, Set, Tuple
 
 import pandas as pd
 from indra.assemblers.indranet import IndraNetAssembler
+from indra.resources import load_resource_json
 from indra.statements import Statement
 from networkx.algorithms import edge_betweenness_centrality
 
@@ -16,8 +17,12 @@ __all__ = [
     "get_go_curation_hashes",
 ]
 
-# TODO can this be imported from INDRA and auto-generated?
-DATABASES = {"biogrid", "hprd", "signor", "phosphoelm", "signor", "biopax"}
+# DATABASES = {"biogrid", "hprd", "signor", "phosphoelm", "signor", "biopax"}
+DATABASES: Set[str] = {
+    key
+    for key, value in load_resource_json("source_info.json").items()
+    if value["type"] == "database"
+}
 
 
 def _keep_by_source(source_counts) -> bool:

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -185,7 +185,7 @@ def get_genes_for_go_term(
     client :
         The Neo4j client.
     go_term :
-        The GO term to query.
+        The GO term to query. Example: ``("GO", "GO:0006915")``
     include_indirect :
         Should ontological children of the given GO term
         be queried as well? Defaults to False.

--- a/src/indra_cogex/client/subnetwork.py
+++ b/src/indra_cogex/client/subnetwork.py
@@ -16,7 +16,7 @@ __all__ = [
 
 
 def indra_subnetwork(
-    client: Neo4jClient, nodes: List[Tuple[str, str]]
+    client: Neo4jClient, nodes: Iterable[Tuple[str, str]]
 ) -> List[Statement]:
     """Return the INDRA Statement subnetwork induced by the given nodes.
 

--- a/src/indra_cogex/client/subnetwork.py
+++ b/src/indra_cogex/client/subnetwork.py
@@ -207,7 +207,7 @@ def indra_subnetwork_go(
     Parameters
     ----------
     go_term :
-        The GO term to query
+        The GO term to query. Example: ``("GO", "GO:0006915")``
     client :
         The Neo4j client.
     include_indirect :

--- a/src/indra_cogex/client/subnetwork.py
+++ b/src/indra_cogex/client/subnetwork.py
@@ -206,27 +206,27 @@ def indra_subnetwork_go(
 
     Parameters
     ----------
-    client :
-        The Neo4j client.
     go_term :
         The GO term to query
+    client :
+        The Neo4j client.
     include_indirect :
         Should ontological children of the given GO term
         be queried as well? Defaults to False.
     mediated:
         Should relations A->X->B be included for X not associated
-        to the given GO term?
+        to the given GO term? Defaults to False.
     upstream_controllers:
         Should relations A<-X->B be included for upstream controller
-        X not associated to the given GO term?
+        X not associated to the given GO term? Defaults to False.
     downstream_targets:
         Should relations A->X<-B be included for downstream target
-        X not associated to the given GO term?
+        X not associated to the given GO term? Defaults to False.
 
     Returns
     -------
     :
-        The subnetwork induced by GO term.
+        The INDRA statement subnetwork induced by GO term.
     """
     genes = get_genes_for_go_term(
         client=client, go_term=go_term, include_indirect=include_indirect
@@ -239,4 +239,6 @@ def indra_subnetwork_go(
         rv.extend(indra_shared_upstream_subnetwork(client=client, nodes=nodes))
     if downstream_targets:
         rv.extend(indra_shared_downstream_subnetwork(client=client, nodes=nodes))
+    # No deduplication of statements based on the union of
+    # the queries should be necessary since each are disjoint
     return rv

--- a/src/indra_cogex/client/subnetwork.py
+++ b/src/indra_cogex/client/subnetwork.py
@@ -46,8 +46,12 @@ def indra_subnetwork(
     return stmts
 
 
+@autoclient()
 def indra_subnetwork_tissue(
-    client: Neo4jClient, nodes: List[Tuple[str, str]], tissue: Tuple[str, str]
+    nodes: List[Tuple[str, str]],
+    tissue: Tuple[str, str],
+    *,
+    client: Neo4jClient,
 ) -> List[Statement]:
     """Return the INDRA Statement subnetwork induced by the given nodes and expressed in the given tissue.
 


### PR DESCRIPTION
Closes #78 

This PR implements a GO term curation workflow that works like this:

1. Look up genes associated with GO term (optionally traversing the GO hierarchy for child GO terms as well)
2. Induce an INDRA statement network for relations between pairs of those genes (by default, just direct, but can be extended to several variations of two-hop queries)
3. Filter out edges only having database evidence, edges already curated, and edges without text
4. Sort statements for curation by edge centrality (i.e., prioritize the edges with most central nodes for curation first)

https://github.com/kkaris/indra_cogex/tree/cogex-landing-page is rebased on top of this branch and includes the front-end curation interface that wraps this