### PR TITLE
Add subnetwork relations query to API

### DIFF
--- a/src/indra_cogex/apps/queries_web/__init__.py
+++ b/src/indra_cogex/apps/queries_web/__init__.py
@@ -121,6 +121,7 @@ for module, func_name in module_functions:
                     code=HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
                     message="Missing application/json header or json body",
                 )
+
             try:
                 parsed_query = parse_json(json_dict)
                 result = func_mapping[self.func_name](**parsed_query, client=client)
@@ -129,9 +130,14 @@ for module, func_name in module_functions:
                     return jsonify({self.func_name: result})
                 else:
                     return jsonify(process_result(result))
+
             except ParseError as err:
                 logger.error(err)
                 abort(code=HTTPStatus.UNSUPPORTED_MEDIA_TYPE, message=str(err))
+
+            except ValueError as err:
+                logger.error(err)
+                abort(code=HTTPStatus.BAD_REQUEST, message=str(err))
 
             except Exception as err:
                 logger.error(err)

--- a/src/indra_cogex/apps/queries_web/helpers.py
+++ b/src/indra_cogex/apps/queries_web/helpers.py
@@ -11,7 +11,15 @@ __all__ = [
     "process_result",
     "get_web_return_annotation",
     "get_docstring",
+    "ParseError",
 ]
+
+
+class ParseError(ValueError):
+    """Raised when the JSON cannot be parsed or is not valid."""
+
+
+MAX_NODES = 400
 
 
 def parse_json(query_json: Dict[str, Any]) -> Dict[str, Any]:
@@ -35,7 +43,14 @@ def parse_json(query_json: Dict[str, Any]) -> Dict[str, Any]:
             elif isinstance(value, list):
                 parsed_query[key] = [int(v) for v in value]
             else:
-                raise ValueError(f"{key} must be a string or list of strings")
+                raise ParseError(f"{key} must be a string or list of strings")
+        elif key == "nodes":
+            if isinstance(value, list):
+                if len(value) > MAX_NODES:
+                    raise ParseError(f"Number of {key} must be less than {MAX_NODES}")
+                parsed_query[key] = value
+            else:
+                raise ParseError(f"{key} must be a list")
         else:
             parsed_query[key] = value
 

--- a/src/indra_cogex/apps/queries_web/helpers.py
+++ b/src/indra_cogex/apps/queries_web/helpers.py
@@ -47,7 +47,7 @@ def parse_json(query_json: Dict[str, Any]) -> Dict[str, Any]:
         elif key == "nodes":
             if isinstance(value, list):
                 if len(value) > MAX_NODES:
-                    raise ParseError(f"Number of {key} must be less than {MAX_NODES}")
+                    raise ValueError(f"Number of {key} must be less than {MAX_NODES}")
                 parsed_query[key] = value
             else:
                 raise ParseError(f"{key} must be a list")


### PR DESCRIPTION
This PR adds a new subnetwork function that returns Relation objects instead of INDRA Statements with the advantage that all the associated metadata (evidence counts, etc.) is returned along with each Statement while the INDRA Statement JSON (from which a Statement can be deserialized) is also included. It also generalizes the API generation to be able to handle multiple modules and includes this new function. @kkaris even though the new endpoint works when called with e.g., `requests`, when trying the Swagger documentation manually, the "Execute" button for some reason doesn't work specifically for this endpoint - not sure why.