### PR TITLE
Bump minimum python version to 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ 3.6, 3.9 ]
+        python-version: [ "3.7", "3.9" ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ classifiers =
     Operating System :: OS Independent
     License :: OSI Approved :: BSD License
     Programming Language :: Python
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -48,7 +47,7 @@ install_requires =
     pandas
 
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.7
 packages = find:
 package_dir =
     = src


### PR DESCRIPTION
3.6 was deprecated in 2021, so it's a both a liability to support this version in case there are security issues/bugs found, as well as the fact that we might want to rely on more modern 3.7+ features. This will also solve the issue where if some of our transitive dependencies have also bumped their minimum version (like numpy and scipy are doing) then we don't get weird conflicts