### PR TITLE
Add mid-level query utilities

### DIFF
--- a/src/indra_cogex/client/curation.py
+++ b/src/indra_cogex/client/curation.py
@@ -461,7 +461,7 @@ def get_conflicting_statements(
         ORDER BY total_evidence_count DESC
         {_limit_line(limit)}
     """
-    res = client.query_tx(query)
+    res = client.query_tx(query, squeeze=True)
     return indra_stmts_from_relations(
-        chain.from_iterable(client.neo4j_to_relations(row[0]) for row in res)
+        chain.from_iterable(client.neo4j_to_relations(row) for row in res)
     )

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -95,7 +95,9 @@ class Neo4jClient:
         """Run a read-only query that generates a dictionary."""
         return dict(self.query_tx(query))
 
-    def query_tx(self, query: str, squeeze: bool = False) -> Union[List[List[Any]], None]:
+    def query_tx(
+        self, query: str, squeeze: bool = False
+    ) -> Union[List[List[Any]], None]:
         """Run a read-only query and return the results.
 
         Parameters
@@ -157,7 +159,9 @@ class Neo4jClient:
             A list of :class:`Relation` instances corresponding
             to the results of the query
         """
-        return [self.neo4j_to_relation(res) for res in self.query_tx(query, squeeze=True)]
+        return [
+            self.neo4j_to_relation(res) for res in self.query_tx(query, squeeze=True)
+        ]
 
     def get_session(self, renew: Optional[bool] = False) -> neo4j.Session:
         """Return an existing session or create one if needed.

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -1158,7 +1158,9 @@ def get_edge_counter(*, client: Neo4jClient) -> Counter:
             relation: client.query_tx(
                 f"MATCH ()-[r:{relation[0]}]->() RETURN count(*)"
             )[0]
-            for relation in client.query_tx("call db.relationshipTypes();", squeeze=True)
+            for relation in client.query_tx(
+                "call db.relationshipTypes();", squeeze=True
+            )
         }
     )
 

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -1027,7 +1027,7 @@ def get_stmts_for_stmt_hashes(
         RETURN p
     """
     logger.info(f"getting statements for {len(stmt_hashes)} hashes")
-    rels = client.query_relations(query)
+    rels = client.query_relations(stmts_query)
     stmts = indra_stmts_from_relations(rels)
 
     if evidence_limit == 1:

--- a/src/indra_cogex/client/subnetwork.py
+++ b/src/indra_cogex/client/subnetwork.py
@@ -45,8 +45,7 @@ def indra_subnetwork_relations(
         nodes_str,
         nodes_str,
     )
-    rels = [client.neo4j_to_relation(p[0]) for p in client.query_tx(query)]
-    return rels
+    return client.query_relations(query)
 
 
 @autoclient()


### PR DESCRIPTION
This PR does the following:

1. Introduces the `squeeze` argument to the `Neo4jClient.query_tx()` function for automatically unpacking the first element of queries that only return one element per row
2. Implements `Neo4jClient.query_nodes()` and `Neo4jClient.query_relations()` functions which allows factoring out the squeezing then conversion into `Node` and `Relationship` classes, respectively.

This should be useful for @kkaris in his current PR, reducing more redundant code, and making it easier to prototype new queries in interactive Python environments