### PR TITLE
Add additional flags as a follow-up to #91

### DIFF
--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -21,7 +21,11 @@ import pystow
 from indra.databases.identifiers import ensure_prefix_if_needed
 from indra.ontology.bio import bio_ontology
 from indra.util import batch_iter
-from indra.util.statement_presentation import db_sources, reader_sources
+from indra.util.statement_presentation import (
+    db_sources,
+    internal_source_mappings,
+    reader_sources,
+)
 from more_click import verbose_option
 from tqdm import tqdm
 
@@ -367,6 +371,9 @@ class EvidenceProcessor(Processor):
                                 evidence["pmid"],
                                 ["Publication"],
                             )
+
+                    source_api = evidence["source_api"]
+                    source_api = internal_source_mappings.get(source_api, source_api)
                     node_batch.append(
                         Node(
                             "indra_evidence",
@@ -375,7 +382,7 @@ class EvidenceProcessor(Processor):
                             {
                                 "evidence:string": json.dumps(evidence),
                                 "stmt_hash:long": stmt_hash,
-                                "source_api:str": evidence["source_api"],
+                                "source_api:str": source_api,
                             },
                         )
                     )

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -227,12 +227,21 @@ class DbProcessor(Processor):
             ) in (
                 self.df[columns].drop_duplicates().values
             ):
+                source_counts_parsed = json.loads(source_counts)
                 data = {
                     "stmt_hash:long": stmt_hash,
                     "source_counts:string": source_counts,
                     "evidence_count:int": evidence_count,
                     "stmt_type:string": stmt_type,
                     "belief:float": belief,
+                    "has_database_evidence:bool": any(
+                        source in db_sources for source in source_counts_parsed
+                    ),
+                    "has_reader_evidence:bool": any(
+                        source in reader_sources for source in source_counts_parsed
+                    ),
+                    "medscan_only:bool": set(source_counts_parsed) == {"medscan"},
+                    "sparser_only:bool": set(source_counts_parsed) == {"sparser"},
                 }
                 total_count += 1
                 yield Relation(
@@ -366,6 +375,7 @@ class EvidenceProcessor(Processor):
                             {
                                 "evidence:string": json.dumps(evidence),
                                 "stmt_hash:long": stmt_hash,
+                                "source_api:str": evidence["source_api"],
                             },
                         )
                     )

--- a/src/indra_cogex/sources/indra_db/__init__.py
+++ b/src/indra_cogex/sources/indra_db/__init__.py
@@ -161,10 +161,10 @@ class DbProcessor(Processor):
                     stmt_json = load_statement_json(pa_json_str)
                     try:
                         values = df_dict[stmt_hash]
-                        source_counts = json.loads(values["source_counts"])
+                        sources = set(json.loads(values["source_counts"]))
                         # For statements with only evidence from medscan,
                         # we don't add an evidence and yield the statement
-                        medscan_only = set(source_counts) == {"medscan"}
+                        medscan_only = sources == {"medscan"}
                         if medscan_only:
                             stmt_json["evidence"] = []
                         # Otherwise, we know that eventually we will bump into
@@ -191,13 +191,13 @@ class DbProcessor(Processor):
                             "belief:float": values["belief"],
                             "stmt_json:string": json.dumps(stmt_json),
                             "has_database_evidence:bool": any(
-                                source in db_sources for source in source_counts
+                                source in db_sources for source in sources
                             ),
                             "has_reader_evidence:bool": any(
-                                source in reader_sources for source in source_counts
+                                source in reader_sources for source in sources
                             ),
                             "medscan_only:bool": medscan_only,
-                            "sparser_only:bool": set(source_counts) == {"sparser"},
+                            "sparser_only:bool": sources == {"sparser"},
                         }
                         total_count += 1
                         hashes_yielded.add(stmt_hash)
@@ -227,7 +227,7 @@ class DbProcessor(Processor):
             ) in (
                 self.df[columns].drop_duplicates().values
             ):
-                source_counts_parsed = json.loads(source_counts)
+                sources = set(json.loads(source_counts))
                 data = {
                     "stmt_hash:long": stmt_hash,
                     "source_counts:string": source_counts,
@@ -235,13 +235,13 @@ class DbProcessor(Processor):
                     "stmt_type:string": stmt_type,
                     "belief:float": belief,
                     "has_database_evidence:bool": any(
-                        source in db_sources for source in source_counts_parsed
+                        source in db_sources for source in sources
                     ),
                     "has_reader_evidence:bool": any(
-                        source in reader_sources for source in source_counts_parsed
+                        source in reader_sources for source in sources
                     ),
-                    "medscan_only:bool": set(source_counts_parsed) == {"medscan"},
-                    "sparser_only:bool": set(source_counts_parsed) == {"sparser"},
+                    "medscan_only:bool": sources == {"medscan"},
+                    "sparser_only:bool": sources == {"sparser"},
                 }
                 total_count += 1
                 yield Relation(


### PR DESCRIPTION
I didn't notice there was branching logic depending on if the JSON was to be uploaded when I did #91, so this adds the same flags to the other branch.

This PR also parses the source API out of the evidence and puts it as a top-level entry in the Evidence nodes.

After this is merged and the database is rebuilt, I'll make a PR for https://github.com/bgyori/indra_cogex/compare/update-curator-queries, which updates the queries to rely on these fields.