### PR TITLE
Add disease-phenotype and phenotype-gene processors from HPO

### DIFF
--- a/src/indra_cogex/apps/constants.py
+++ b/src/indra_cogex/apps/constants.py
@@ -26,6 +26,8 @@ edge_labels = {
     "tested_in": "Drug Trials",
     "sensitive_to": "Sensitivities",
     "has_indication": "Drug Indications",
+    "has_phenotype": "Disease Phenotypes",
+    "phenotype_has_gene": "Phenotype Genes",
 }
 
 INDRA_COGEX_WEB_LOCAL = (get_config("INDRA_COGEX_WEB_LOCAL") or "").lower() in {

--- a/src/indra_cogex/apps/gla/fields.py
+++ b/src/indra_cogex/apps/gla/fields.py
@@ -47,6 +47,7 @@ source_field = RadioField(
         ("go", "Gene Ontology"),
         ("reactome", "Reactome"),
         ("wikipathways", "WikiPathways"),
+        ("phenotype", "HPO Phenotypes"),
         ("indra-upstream", "INDRA Upstream"),
         ("indra-downstrea", "INDRA Downstream"),
     ],

--- a/src/indra_cogex/apps/gla/gene_blueprint.py
+++ b/src/indra_cogex/apps/gla/gene_blueprint.py
@@ -40,6 +40,7 @@ from ...client.enrichment.discrete import (
     go_ora,
     indra_downstream_ora,
     indra_upstream_ora,
+    phenotype_ora,
     reactome_ora,
     wikipathways_ora,
 )
@@ -203,6 +204,13 @@ def discretize_analysis():
             alpha=alpha,
             keep_insignificant=keep_insignificant,
         )
+        phenotype_results = phenotype_ora(
+            gene_set,
+            client=client,
+            method=method,
+            alpha=alpha,
+            keep_insignificant=keep_insignificant,
+        )
         if form.indra_path_analysis.data:
             indra_upstream_results = indra_upstream_ora(
                 client,
@@ -237,6 +245,9 @@ def discretize_analysis():
             reactome_results.to_csv(
                 downloads.joinpath("reactome_results.tsv"), sep="\t", index=False
             )
+            phenotype_results.to_csv(
+                downloads.joinpath("phenotype_results.tsv"), sep="\t", index=False
+            )
             if form.indra_path_analysis.data:
                 indra_downstream_results.to_csv(
                     downloads.joinpath("indra_downstream_results.tsv"),
@@ -260,6 +271,7 @@ def discretize_analysis():
             go_results=go_results,
             wikipathways_results=wikipathways_results,
             reactome_results=reactome_results,
+            phenotype_results=phenotype_results,
             indra_downstream_results=indra_downstream_results,
             indra_upstream_results=indra_upstream_results,
         )

--- a/src/indra_cogex/apps/gla/gene_blueprint.py
+++ b/src/indra_cogex/apps/gla/gene_blueprint.py
@@ -18,6 +18,7 @@ from indra_cogex.client.enrichment.continuous import (
     get_mouse_scores,
     indra_downstream_gsea,
     indra_upstream_gsea,
+    phenotype_gsea,
     reactome_gsea,
     wikipathways_gsea,
 )
@@ -347,6 +348,14 @@ def continuous_analysis():
             )
         elif source == "reactome":
             results = reactome_gsea(
+                client=client,
+                scores=scores,
+                permutation_num=permutations,
+                alpha=alpha,
+                keep_insignificant=keep_insignificant,
+            )
+        elif source == "phenotype":
+            results = phenotype_gsea(
                 client=client,
                 scores=scores,
                 permutation_num=permutations,

--- a/src/indra_cogex/apps/templates/gene_analysis/continuous_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/continuous_results.html
@@ -67,6 +67,8 @@
                         WikiPathways.
                     {% elif source == "reactome" %}
                         Reactome.
+                    {% elif source == "phenotype" %}
+                        HPO Phenotypes.
                     {% elif source == "indra-upstream" %}
                         INDRA upstream controllers.
                     {% elif source == "indra-downstream" %}

--- a/src/indra_cogex/apps/templates/gene_analysis/discrete_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/discrete_results.html
@@ -22,6 +22,7 @@
             $("#table-go").DataTable(datatablesConf);
             $("#table-reactome").DataTable(datatablesConf);
             $("#table-wikipathways").DataTable(datatablesConf);
+            $("#table-phenotype").DataTable(datatablesConf);
             {% if indra_downstream_results is not none %}
             $("#table-downstream").DataTable(datatablesConf);
             $("#table-upstream").DataTable(datatablesConf);
@@ -139,6 +140,14 @@
                             pathway database.
                         </p>
                         {{ render_table(wikipathways_results, "table-wikipathways") }}
+                    </div>
+                    <div class="tab-pane" id="wikipathways" role="tabpanel" aria-labelledby="wikipathways-tab">
+                        <p>
+                            These results are acquired by running over-representation analysis using Fisher's exact test
+                            and correcting using {{ method }} and α={{ alpha }} on the genes annotated to phenotypes in
+                            the <a href="https://hpo.jax.org/">Human Phenotype Ontology annotation database</a>.
+                        </p>
+                        {{ render_table(phenotype_results, "table-phenotype") }}
                     </div>
                     {% if indra_downstream_results is not none %}
                         <div class="tab-pane" id="downstream" role="tabpanel" aria-labelledby="downstream-tab">

--- a/src/indra_cogex/client/enrichment/continuous.py
+++ b/src/indra_cogex/client/enrichment/continuous.py
@@ -23,6 +23,7 @@ from indra_cogex.client.enrichment.utils import (
     get_entity_to_regulators,
     get_entity_to_targets,
     get_go,
+    get_phenotype_gene_sets,
     get_reactome,
     get_wikipathways,
 )
@@ -35,6 +36,7 @@ __all__ = [
     "go_gsea",
     "wikipathways_gsea",
     "reactome_gsea",
+    "phenotype_gsea",
     "indra_upstream_gsea",
     "indra_downstream_gsea",
     "gsea",
@@ -284,6 +286,42 @@ def reactome_gsea(
     """
     return gsea(
         gene_sets=get_reactome(client=client),
+        scores=scores,
+        directory=directory,
+        **kwargs,
+    )
+
+
+@autoclient()
+def phenotype_gsea(
+    scores: Dict[str, float],
+    directory: Union[None, Path, str] = None,
+    *,
+    client: Neo4jClient,
+    **kwargs,
+) -> pd.DataFrame:
+    """Run GSEA with HPO phenotype gene sets.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    scores :
+        A mapping from HGNC gene identifiers to floating point scores
+        (e.g., from a differential gene expression analysis)
+    directory :
+        Specify the directory if the results should be saved, including
+        both a dataframe and plots for each gen set
+    kwargs :
+        Remaining keyword arguments to pass through to :func:`gseapy.prerank`
+
+    Returns
+    -------
+    :
+        A pandas dataframe with the GSEA results
+    """
+    return gsea(
+        gene_sets=get_phenotype_gene_sets(client=client),
         scores=scores,
         directory=directory,
         **kwargs,

--- a/src/indra_cogex/client/enrichment/discrete.py
+++ b/src/indra_cogex/client/enrichment/discrete.py
@@ -13,6 +13,7 @@ from indra_cogex.client.enrichment.utils import (
     get_entity_to_regulators,
     get_entity_to_targets,
     get_go,
+    get_phenotype_gene_sets,
     get_reactome,
     get_wikipathways,
 )
@@ -23,6 +24,7 @@ __all__ = [
     "go_ora",
     "wikipathways_ora",
     "reactome_ora",
+    "phenotype_ora",
     "indra_downstream_ora",
     "indra_upstream_ora",
 ]
@@ -248,6 +250,33 @@ def reactome_ora(
     return _do_ora(get_reactome(client=client), query=gene_ids, count=count, **kwargs)
 
 
+@autoclient()
+def phenotype_ora(
+    gene_ids: Iterable[str], *, client: Neo4jClient, **kwargs
+) -> pd.DataFrame:
+    """Calculate over-representation on all HP phenotypes.
+
+    Parameters
+    ----------
+    gene_ids :
+        List of gene identifiers
+    client :
+        Neo4jClient
+    **kwargs :
+        Additional keyword arguments to pass to _do_ora
+
+    Returns
+    -------
+    :
+        DataFrame with columns:
+        curie, name, p, q, mlp, mlq
+    """
+    count = count_human_genes(client=client)
+    return _do_ora(
+        get_phenotype_gene_sets(client=client), query=gene_ids, count=count, **kwargs
+    )
+
+
 def indra_downstream_ora(
     client: Neo4jClient,
     gene_ids: Iterable[str],
@@ -355,6 +384,12 @@ def main():
     print("\n## Reactome Enrichment\n")
     print(
         reactome_ora(client=client, gene_ids=EXAMPLE_GENE_IDS)
+        .head(15)
+        .to_markdown(index=False)
+    )
+    print("\n## Phenotype Enrichment\n")
+    print(
+        phenotype_ora(client=client, gene_ids=EXAMPLE_GENE_IDS)
         .head(15)
         .to_markdown(index=False)
     )

--- a/src/indra_cogex/client/enrichment/utils.py
+++ b/src/indra_cogex/client/enrichment/utils.py
@@ -264,7 +264,7 @@ def get_reactome(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set[str]]:
     return collect_gene_sets(client=client, query=query, cache_file=cache_file)
 
 
-@autoclient(cache=True)
+@autoclient()
 def get_phenotype_gene_sets(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set[str]]:
     """Get HPO phenotype gene sets.
 
@@ -279,6 +279,7 @@ def get_phenotype_gene_sets(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set
         A dictionary whose keys that are 2-tuples of CURIE and name of each phenotype
         gene set and whose values are sets of HGNC gene identifiers (as strings)
     """
+    cache_file = pystow.join("indra", "cogex", "app_cache", name="hpo.pkl")
     query = dedent(
         """\
         MATCH (s:BioEntity)-[:phenotype_has_gene]-(gene:BioEntity)
@@ -287,7 +288,7 @@ def get_phenotype_gene_sets(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set
     """
     )
     logger.info("caching phenotype gene sets with Cypher query: %s", query)
-    return collect_gene_sets(client=client, query=query)
+    return collect_gene_sets(client=client, query=query, cache_file=cache_file)
 
 
 @autoclient()

--- a/src/indra_cogex/client/enrichment/utils.py
+++ b/src/indra_cogex/client/enrichment/utils.py
@@ -36,7 +36,7 @@ GENE_SET_CACHE = {}
 def collect_gene_sets(
     query: str,
     *,
-    cache_file: Path = None,
+    cache_file: Path,
     client: Neo4jClient,
     include_ontology_children: bool = False,
 ) -> Dict[Tuple[str, str], Set[str]]:

--- a/src/indra_cogex/sources/__init__.py
+++ b/src/indra_cogex/sources/__init__.py
@@ -19,6 +19,7 @@ from .pathways import ReactomeProcessor, WikipathwaysProcessor
 from .processor import Processor
 from .pubmed import PubmedProcessor
 from .sider import SIDERSideEffectProcessor
+from .hpoa import HpDiseasePhenotypeProcessor, HpPhenotypeGeneProcessor
 
 __all__ = [
     "processor_resolver",
@@ -37,6 +38,8 @@ __all__ = [
     "SIDERSideEffectProcessor",
     "EvidenceProcessor",
     "PubmedProcessor",
+    "HpDiseasePhenotypeProcessor",
+    "HpPhenotypeGeneProcessor",
 ]
 
 processor_resolver = Resolver.from_subclasses(Processor)

--- a/src/indra_cogex/sources/hpoa/__init__.py
+++ b/src/indra_cogex/sources/hpoa/__init__.py
@@ -211,7 +211,7 @@ class HpPhenotypeGeneProcessor(Processor):
                 db_ns=prefix, db_id=identifier, name=name, labels=["BioEntity"]
             )
         for hgnc_id in self.df.hgnc_id.unique():
-            yield Node.standardized(db_ns="hgnc", db_id=hgnc_id, labels=["BioEntity"])
+            yield Node.standardized(db_ns="HGNC", db_id=hgnc_id, labels=["BioEntity"])
 
     def get_relations(self):  # noqa:D102
         for (phenotype_prefix, phenotype_id, hgnc_id,), evidences in self.df.groupby(

--- a/src/indra_cogex/sources/hpoa/__init__.py
+++ b/src/indra_cogex/sources/hpoa/__init__.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+
+"""Processor for the Human Phenotype Ontology Associations (HPOA) database."""
+
+import logging
+from typing import Optional
+
+import bioregistry
+import pandas as pd
+import pyobo
+from indra.ontology.standardize import standardize_name_db_refs
+from indra.statements.agent import get_grounding
+
+from ..processor import Processor
+from ...representation import Node, Relation
+
+logger = logging.getLogger(__name__)
+
+
+# DISEASE_GENE_URL = "http://purl.obolibrary.org/obo/hp/hpoa/phenotype_to_genes.txt"
+
+
+class HpoaProcessor(Processor):
+    """Processor for the Human Phenotype Ontology Annotations (HPOA) database."""
+
+    name = "hpoa"
+    df: pd.DataFrame
+    node_types = ["BioEntity"]
+    rel_type = "has_phenotype"
+
+    def __init__(
+        self, df: Optional[pd.DataFrame] = None, version: Optional[str] = None
+    ):
+        """Initialize the HPOA processor."""
+        self.df = get_df(version=version) if df is None else df
+        self.version = version
+
+    def get_nodes(self):  # noqa:D102
+        for prefix, identifier, name in df_unique(
+            self.df[["disease_prefix", "disease_id", "disease_name"]]
+        ):
+            yield Node.standardized(
+                db_ns=prefix, db_id=identifier, name=name, labels=["BioEntity"]
+            )
+        for prefix, identifier, name in df_unique(
+            self.df[["phenotype_prefix", "phenotype_id", "phenotype_name"]]
+        ):
+            yield Node.standardized(
+                db_ns=prefix, db_id=identifier, name=name, labels=["BioEntity"]
+            )
+
+    def get_relations(self):  # noqa:D102
+        for (
+            disease_prefix,
+            disease_id,
+            phenotype_prefix,
+            phenotype_id,
+        ), evidence in self.df.groupby(
+            ["disease_prefix", "disease_id", "phenotype_prefix", "phenotype_id"]
+        )[
+            "evidence"
+        ]:
+            all_ecs = ",".join(sorted(set(evidence)))
+            # Possible properties could be e.g., evidence codes
+            data = {"evidence_codes:string": all_ecs, "source": self.name}
+            if self.version:
+                data["version"] = self.version
+            yield Relation(
+                disease_prefix,
+                disease_id,
+                phenotype_prefix,
+                phenotype_id,
+                self.rel_type,
+                data,
+            )
+
+
+def df_unique(df: pd.DataFrame):
+    """Get unique rows in the dataframe as sorted tuples."""
+    return sorted({tuple(row) for row in df.values})
+
+
+def get_df(version: Optional[str] = None) -> pd.DataFrame:
+    """Get the HPOA database as a preprocessed dataframe.
+
+    Parameters
+    ----------
+    version :
+        An optional version in form of a string YYYY-MM-DD. If not given,
+        gets the latest data.
+    Returns
+    -------
+    :
+        A parsed and preprocessed HPO annotation dataframe
+    """
+    if version is None:
+        url = "http://purl.obolibrary.org/obo/hp/hpoa/phenotype.hpoa"
+    else:
+        url = (
+            f"http://purl.obolibrary.org/obo/hp/releases/hpoa/{version}/phenotype.hpoa"
+        )
+    df = pd.read_csv(
+        url,
+        sep="\t",
+        skiprows=5,
+        usecols=[0, 3, 4, 5],
+        names=["disease", "phenotype", "reference", "evidence"],
+    )
+    df.drop_duplicates(inplace=True)
+    return process_df(df)
+
+
+def process_df(df: pd.DataFrame) -> pd.DataFrame:
+    """Process the HPOA dataframe, in place."""
+    # 1. Get several mappings not currently available in INDRA's bioontology
+    omim_to_mondo = pyobo.get_filtered_xrefs("mondo", "omim", flip=True)
+    mondo_to_doid = pyobo.get_filtered_xrefs("mondo", "doid")
+    orphanet_to_mondo = pyobo.get_filtered_xrefs("mondo", "orphanet", flip=True)
+    omim_to_doid = pyobo.get_filtered_xrefs("doid", "omim", flip=True)
+
+    # Prepare disease mappings from CURIE (either OMIM, Orphanet,
+    # or DECIPHER) to DOID and MONDO
+    disease_standards = {}
+    for disease in df.disease:
+        prefix, lui = bioregistry.parse_curie(disease)
+        db_xrefs = {
+            prefix: lui,
+        }
+        mondo_id = None
+        if prefix == "omim":
+            do_id = omim_to_doid.get(lui)
+            if do_id:
+                db_xrefs["DOID"] = f"DOID:{do_id}"
+            mondo_id = omim_to_mondo.get(lui)
+            if mondo_id:
+                db_xrefs["MONDO"] = mondo_id
+        if prefix == "orphanet":
+            mondo_id = orphanet_to_mondo.get(lui)
+            if mondo_id:
+                db_xrefs["MONDO"] = mondo_id
+        if mondo_id:
+            do_id = mondo_to_doid.get(mondo_id)
+            if do_id:
+                db_xrefs["DOID"] = f"DOID:{do_id}"
+
+        new_name, new_db_xrefs = standardize_name_db_refs(db_xrefs)
+        standard_db, standard_id = get_grounding(new_db_xrefs)
+        if not new_name:
+            continue
+        disease_standards[disease] = standard_db, standard_id, new_name
+
+    (
+        df["disease_prefix"],
+        df["disease_id"],
+        df["disease_name"],
+    ) = zip(*df["disease"].map(lambda s: disease_standards.get(s, (None, None, None))))
+    del df["disease"]
+    # Remove unmappable entries (e.g., DECIPHER entries)
+    df = df[df.disease_prefix.notna()]
+
+    phenotype_standards = {}
+    for hp_id in df.phenotype.unique():
+        new_name, new_db_xrefs = standardize_name_db_refs({"HP": hp_id})
+        standard_db, standard_id = get_grounding(new_db_xrefs)
+        if not new_name:
+            continue
+        phenotype_standards[hp_id] = standard_db, standard_id, new_name
+
+    (df["phenotype_prefix"], df["phenotype_id"], df["phenotype_name"],) = zip(
+        *df["phenotype"].map(lambda s: phenotype_standards.get(s, (None, None, None)))
+    )
+    del df["phenotype"]
+    df = df[df.phenotype_prefix.notna()]
+    return df

--- a/src/indra_cogex/sources/hpoa/__main__.py
+++ b/src/indra_cogex/sources/hpoa/__main__.py
@@ -2,7 +2,19 @@
 
 """Run the HPOA processor using ``python -m indra_cogex.sources.hpoa``."""
 
-from . import HpoaProcessor
+import click
+from more_click import verbose_option
+
+from . import HpDiseasePhenotypeProcessor, HpPhenotypeGeneProcessor
+
+
+@click.command()
+@verbose_option
+@click.pass_context
+def _main(ctx: click.Context):
+    ctx.invoke(HpDiseasePhenotypeProcessor.get_cli())
+    ctx.invoke(HpPhenotypeGeneProcessor.get_cli())
+
 
 if __name__ == "__main__":
-    HpoaProcessor.cli()
+    _main()

--- a/src/indra_cogex/sources/hpoa/__main__.py
+++ b/src/indra_cogex/sources/hpoa/__main__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+"""Run the HPOA processor using ``python -m indra_cogex.sources.hpoa``."""
+
+from . import HpoaProcessor
+
+if __name__ == "__main__":
+    HpoaProcessor.cli()

--- a/tox.ini
+++ b/tox.ini
@@ -88,8 +88,10 @@ deps =
 skip_install = true
 commands =
     black src/indra_cogex/client src/indra_cogex/apps src/indra_cogex/resources tests/ \
+        src/indra_cogex/sources/hpoa/ \
         src/indra_cogex/sources/indra_db/
     isort src/indra_cogex/client src/indra_cogex/apps src/indra_cogex/resources \
+        src/indra_cogex/sources/hpoa/ \
         src/indra_cogex/sources/indra_db/
 description = Apply automatic formatters
 


### PR DESCRIPTION
This PR does the following:

1. Adds a processor for disease-phenotype relationships from HPO. Since HPO lists diseases with OMIM, Orphanet, and DECIPHER identifiers, it uses a combination of PyOBO and the INDRA Bioontology to standardize them.
2. Adds a processor for phenotype-gene relationships from HPO. Note that these are derived from disease-gene relationships, but still pretty useful.
3. Extends the backend for both discrete and continous gene-set enrichment analysis and make them available in the web app

Some things to discuss:

1. What should the relationships be called for these two?
2. Would it make sense to extend the Bioontology to handle OMIM and MONDO mappings to take care of this better?