### PR TITLE
Statement page fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install tox
-          BIOONTOLOGY_VERSION=1.22
+          BIOONTOLOGY_VERSION=1.23
           echo "bio ontology version: ${BIOONTOLOGY_VERSION}"
           mkdir -p $HOME/.indra/bio_ontology/$BIOONTOLOGY_VERSION
           wget -nv https://bigmech.s3.amazonaws.com/travis/bio_ontology/$BIOONTOLOGY_VERSION/mock_ontology.pkl -O $HOME/.indra/bio_ontology/$BIOONTOLOGY_VERSION/bio_ontology.pkl

--- a/src/indra_cogex/apps/constants.py
+++ b/src/indra_cogex/apps/constants.py
@@ -41,8 +41,8 @@ SOURCE_BADGES_CSS = STATIC_DIR / "source_badges.css"
 
 # Set VUE parameters
 sources_dict = {
-    "reading": [r for r in reader_sources],
     "databases": [d for d in db_sources],
+    "reading": [r for r in reader_sources],
 }
 
 # Check for source_badges.css, and generate if it doesn't exist

--- a/src/indra_cogex/apps/data_display/__init__.py
+++ b/src/indra_cogex/apps/data_display/__init__.py
@@ -251,6 +251,7 @@ def statement_display():
             int(r.data["stmt_hash"]): json.loads(r.data["source_counts"])
             for r in relations
         }
+        available_sources = set().union(*source_counts.values())
 
         # Get the formatted evidence rows
         stmts = format_stmts(
@@ -258,13 +259,19 @@ def statement_display():
             evidence_counts=ev_counts,
             source_counts_per_hash=source_counts,
         )
+
+        available_sources_dict = {}
+        for src_type, sources in sources_dict.items():
+            available_sources_dict[src_type] = [
+                src for src in sources if src in available_sources
+            ]
         return render_template(
             "data_display/data_display_base.html",
             stmts=stmts,
             user_email=email,
             vue_src_js=VUE_SRC_JS,
             vue_src_css=VUE_SRC_CSS,
-            sources_dict=sources_dict,
+            sources_dict=available_sources_dict,
         )
     except Exception as err:
         logger.exception(err)

--- a/src/indra_cogex/apps/templates/data_display/data_display_base.html
+++ b/src/indra_cogex/apps/templates/data_display/data_display_base.html
@@ -61,7 +61,7 @@
             <h4 class="my-0 font-weight-normal">
                 {% if title %}{{ title }}{% else %}CoGEx Statements{% endif %}
             </h4>
-            Readers - <source-display></source-display> - Databases
+            Databases - <source-display></source-display> - Readers
         </div>
         {% if stmts|length == 0 %}
             <div class="card-body">


### PR DESCRIPTION
This PR updates the order for the sources so that the source badges in the statements view have the databases first/to the left and readers second/to the right.

The sources shown at the top are also dependent on which sources are actually present in the loaded statements.