### PR TITLE
Medscan fix

### DIFF
--- a/src/indra_cogex/apps/data_display/__init__.py
+++ b/src/indra_cogex/apps/data_display/__init__.py
@@ -220,6 +220,7 @@ def get_evidence(stmt_hash):
 def statement_display():
     user, roles = resolve_auth(dict(request.args))
     email = user.email if user else ""
+    remove_medscan = user is None
 
     # Get the statements hash from the query string
     try:
@@ -262,9 +263,15 @@ def statement_display():
 
         available_sources_dict = {}
         for src_type, sources in sources_dict.items():
-            available_sources_dict[src_type] = [
-                src for src in sources if src in available_sources
-            ]
+            available_sources_dict[src_type] = []
+            for source in sources:
+                if source in available_sources:
+                    # If not logged in, skip medscan
+                    if remove_medscan and source == "medscan":
+                        continue
+
+                    available_sources_dict[src_type].append(source)
+
         return render_template(
             "data_display/data_display_base.html",
             stmts=stmts,

--- a/src/indra_cogex/apps/utils.py
+++ b/src/indra_cogex/apps/utils.py
@@ -294,6 +294,7 @@ def _stmt_to_row(
                 "color": "#28a745",
                 "symbol": "\u270E",
                 "title": f"{num} evidences curated as correct",
+                "loc": "left",
             }
         )
 


### PR DESCRIPTION
This PR updates the handling of requests to `/statement_display` so that medscan is removed when necessary.

Two other updates in this PR:

- Two for loops are merged to one, which should make things more efficient
- The curation badge at the statement level now has a location specified which previously made the rendering bad

Test locally by loading statements that have some medscan, e.g. `-22470740286509891`, or only medscan (e.g. `-22478113093459888`)