### PR TITLE
Speed up enrichment analysis gene set usage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install tox
-          BIOONTOLOGY_VERSION=1.23
+          BIOONTOLOGY_VERSION=1.25
           echo "bio ontology version: ${BIOONTOLOGY_VERSION}"
           mkdir -p $HOME/.indra/bio_ontology/$BIOONTOLOGY_VERSION
           wget -nv https://bigmech.s3.amazonaws.com/travis/bio_ontology/$BIOONTOLOGY_VERSION/mock_ontology.pkl -O $HOME/.indra/bio_ontology/$BIOONTOLOGY_VERSION/bio_ontology.pkl

--- a/src/indra_cogex/apps/wsgi.py
+++ b/src/indra_cogex/apps/wsgi.py
@@ -2,6 +2,7 @@
 
 """Full INDRA CoGEx web app suite."""
 
+import logging
 import os
 
 from flask import Flask
@@ -16,6 +17,28 @@ from indra_cogex.apps.gla.metabolite_blueprint import metabolite_blueprint
 from indra_cogex.apps.home import home_blueprint
 from indra_cogex.apps.queries_web import api
 from indra_cogex.client.neo4j_client import Neo4jClient
+
+
+logger = logging.getLogger(__name__)
+
+
+def build_caches():
+    logger.info("Building up caches for gene set enrichment analysis...")
+    from indra_cogex.client.enrichment.utils import (
+        get_entity_to_targets,
+        get_entity_to_regulators,
+        get_go,
+        get_reactome,
+        get_wikipathways,
+    )
+
+    get_go()
+    get_reactome()
+    get_wikipathways()
+    get_entity_to_targets()
+    get_entity_to_regulators()
+    logger.info("Finished building caches for gene set enrichment analysis.")
+
 
 app = Flask(__name__, template_folder=TEMPLATES_DIR, static_folder=STATIC_DIR)
 app.register_blueprint(auth)
@@ -38,3 +61,4 @@ app.config["SWAGGER_UI_DOC_EXPANSION"] = "list"
 app.config["EXPLAIN_TEMPLATE_LOADING"] = False
 
 bootstrap = Bootstrap4(app)
+build_caches()

--- a/src/indra_cogex/apps/wsgi.py
+++ b/src/indra_cogex/apps/wsgi.py
@@ -35,8 +35,8 @@ def build_caches():
     get_go()
     get_reactome()
     get_wikipathways()
-    get_entity_to_targets()
-    get_entity_to_regulators()
+    get_entity_to_targets(minimum_evidence_count=1, minimum_belief=0.0)
+    get_entity_to_regulators(minimum_evidence_count=1, minimum_belief=0.0)
     logger.info("Finished building caches for gene set enrichment analysis.")
 
 

--- a/src/indra_cogex/client/enrichment/utils.py
+++ b/src/indra_cogex/client/enrichment/utils.py
@@ -222,8 +222,8 @@ def get_reactome(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set[str]]:
 def get_entity_to_targets(
     *,
     client: Neo4jClient,
-    minimum_evidence_count: Optional[int] = None,
-    minimum_belief: Optional[float] = None,
+    minimum_evidence_count: Optional[int] = 1,
+    minimum_belief: Optional[float] = 0.0,
 ) -> Dict[Tuple[str, str], Set[str]]:
     """Get a mapping from each entity in the INDRA database to the set of
     human genes that it regulates.


### PR DESCRIPTION
This PR makes the following changes to gene set analysis queries:
- It implements a new Cypher query that pulls out beliefs and evidence counts along with targets/regulators when collecting genes.
- It implements a new data structure that maintais the maximum belief and maximum evidence count for each target/regulator.
- File-based caching is implemented for each gene set, these only need to be updated when a new graph DB is deployed.
- In-memory caching is implemented without relying on lru_cache that is hard to control and takes arguments into account that shouldn't be considered.
- The app startup script initialized the caches (i.e., generates the cached files and then loads them into memory).