### PR TITLE
GO parent terms in enrichment analysis

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     more_click>=0.1.1
     class-resolver>=0.0.9
     pystow>=0.1.6
+    bioregistry<0.5
     pyobo
     numpy
     scipy<1.8.0 # https://github.com/scipy/scipy/issues/16079

--- a/src/indra_cogex/client/enrichment/discrete.py
+++ b/src/indra_cogex/client/enrichment/discrete.py
@@ -252,8 +252,8 @@ def indra_downstream_ora(
     client: Neo4jClient,
     gene_ids: Iterable[str],
     *,
-    minimum_evidence_count: Optional[int] = None,
-    minimum_belief: Optional[float] = None,
+    minimum_evidence_count: Optional[int] = 1,
+    minimum_belief: Optional[float] = 0.0,
     **kwargs,
 ) -> pd.DataFrame:
     """
@@ -297,8 +297,8 @@ def indra_upstream_ora(
     client: Neo4jClient,
     gene_ids: Iterable[str],
     *,
-    minimum_evidence_count: Optional[int] = None,
-    minimum_belief: Optional[float] = None,
+    minimum_evidence_count: Optional[int] = 1,
+    minimum_belief: Optional[float] = 0.0,
     **kwargs,
 ) -> pd.DataFrame:
     """

--- a/src/indra_cogex/client/enrichment/utils.py
+++ b/src/indra_cogex/client/enrichment/utils.py
@@ -34,6 +34,7 @@ def collect_gene_sets(
     *,
     cache_file: Path = None,
     client: Neo4jClient,
+    include_ontology_children: bool = False,
 ) -> Dict[Tuple[str, str], Set[str]]:
     """Collect gene sets based on the given query.
 
@@ -73,6 +74,10 @@ def collect_gene_sets(
             }
             curie_to_hgnc_ids[curie, name].update(hgnc_ids)
         res = dict(curie_to_hgnc_ids)
+
+        if include_ontology_children:
+            extend_by_ontology(res)
+
         with open(cache_file, "wb") as fh:
             pickle.dump(res, fh)
     GENE_SET_CACHE[cache_file.as_posix()] = res
@@ -205,7 +210,12 @@ def get_go(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set[str]]:
         RETURN term.id, term.name, collect(gene.id) as gene_curies;
     """
     )
-    return collect_gene_sets(client=client, query=query, cache_file=cache_file)
+    return collect_gene_sets(
+        client=client,
+        query=query,
+        cache_file=cache_file,
+        include_ontology_children=True,
+    )
 
 
 @autoclient()

--- a/src/indra_cogex/client/enrichment/utils.py
+++ b/src/indra_cogex/client/enrichment/utils.py
@@ -40,10 +40,15 @@ def collect_gene_sets(
 
     Parameters
     ----------
+    cache_file :
+        The path to the cache file.
     query:
         A cypher query
     client :
         The Neo4j client.
+    include_ontology_children :
+        If True, extend the gene set associations with associations from
+        child terms using the indra ontology
 
     Returns
     -------
@@ -194,7 +199,7 @@ def get_go(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set[str]]:
 
     Parameters
     ----------
-    client :object
+    client :
         The Neo4j client.
 
     Returns

--- a/src/indra_cogex/client/enrichment/utils.py
+++ b/src/indra_cogex/client/enrichment/utils.py
@@ -79,6 +79,41 @@ def collect_gene_sets(
     return res
 
 
+def extend_by_ontology(gene_set_mapping: Dict[Tuple[str, str], Set[str]]):
+    """Extend the gene set mapping by ontology."""
+    from indra.ontology.bio import bio_ontology
+    from indra.databases.identifiers import ensure_prefix_if_needed
+
+    # The bio_ontology contains upper case db names and sometimes double prefixes
+    # (e.g. "GO:GO:123456"), the gene_set_mapping contains lower case db
+    # names and don't have double prefixes, e.g. "go:123456".
+
+    bio_ontology.initialize()
+    # Keys are tuples of (curie, name)
+    for curie, name in gene_set_mapping:
+
+        # Upper case the curie and split it into prefix and identifier
+        db_ns, db_id = curie.upper().split(":")
+
+        # See if prefix is needed in the identifier
+        db_id = ensure_prefix_if_needed(db_ns, db_id)
+
+        # Loop the ontology children and add them to the mapping
+        for child_ns, child_id in bio_ontology.get_children(db_ns, db_id):
+            child_name = bio_ontology.get_name(child_ns, child_id)
+            child_curie = child_ns + ":" + child_id
+
+            # Lowercase and remove double prefix for matching the keys in
+            # the mapping
+            child_curie = child_curie.replace(
+                f"{child_ns}:" f"{child_ns}:", f"{child_ns}:"
+            ).lower()
+
+            gene_set_mapping[curie, name] |= gene_set_mapping.get(
+                (child_curie, child_name), set()
+            )
+
+
 @autoclient()
 def collect_genes_with_confidence(
     query: str,

--- a/tests/test_enrichment_utils.py
+++ b/tests/test_enrichment_utils.py
@@ -1,0 +1,29 @@
+from indra_cogex.client.enrichment.utils import extend_by_ontology
+
+
+def test_extend_by_ontology():
+    # Create a mapping with some of the hgnc IDs
+    gene_set_mapping = {
+        (
+            "go:0000978",
+            "RNA polymerase II cis-regulatory region sequence-specific DNA binding",
+        ): {
+            "123",
+            "456",
+            "789",
+            "120",
+            "654",
+        },
+        ("go:0035497", "cAMP response element binding"): {
+            "711",
+            "852",
+            "963",
+            "159",
+            "357",
+        },
+    }
+
+    # Extend the mapping by the GO ontology
+    len_before = sum(map(lambda x: len(x), gene_set_mapping.values()))
+    extend_by_ontology(gene_set_mapping)
+    assert sum(map(lambda x: len(x), gene_set_mapping.values())) > len_before

--- a/tests/test_enrichment_utils.py
+++ b/tests/test_enrichment_utils.py
@@ -4,17 +4,14 @@ from indra_cogex.client.enrichment.utils import extend_by_ontology
 def test_extend_by_ontology():
     # Create a mapping with some of the hgnc IDs
     gene_set_mapping = {
-        (
-            "go:0000978",
-            "RNA polymerase II cis-regulatory region sequence-specific DNA binding",
-        ): {
+        ("go:0008150", "biological_process",): {
             "123",
             "456",
             "789",
             "120",
             "654",
         },
-        ("go:0035497", "cAMP response element binding"): {
+        ("go:0009987", "cellular process"): {
             "711",
             "852",
             "963",

--- a/tests/test_enrichment_utils.py
+++ b/tests/test_enrichment_utils.py
@@ -4,14 +4,14 @@ from indra_cogex.client.enrichment.utils import extend_by_ontology
 def test_extend_by_ontology():
     # Create a mapping with some of the hgnc IDs
     gene_set_mapping = {
-        ("go:0008150", "biological_process",): {
+        ("go:0001837", "epithelial to mesenchymal transition",): {
             "123",
             "456",
             "789",
             "120",
             "654",
         },
-        ("go:0009987", "cellular process"): {
+        ("go:0048762", "mesenchymal cell differentiation"): {
             "711",
             "852",
             "963",
@@ -23,4 +23,6 @@ def test_extend_by_ontology():
     # Extend the mapping by the GO ontology
     len_before = sum(map(lambda x: len(x), gene_set_mapping.values()))
     extend_by_ontology(gene_set_mapping)
-    assert sum(map(lambda x: len(x), gene_set_mapping.values())) > len_before
+    assert (
+        sum(map(lambda x: len(x), gene_set_mapping.values())) > len_before
+    ), gene_set_mapping


### PR DESCRIPTION
This PR implements a helper function that extends gene set mappings of go terms to include child gene sets. The helper function is written to be agnostic of namespace but is currently only used for go - gene set mappings.