### PR TITLE
Optimize queries for all relations

### DIFF
--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -419,9 +419,8 @@ class Neo4jClient:
         self,
         node: Tuple[str, str],
         relation: Optional[str] = None,
-        source_type: Optional[str] = None,
-        target_type: Optional[str] = None,
         node_type: Optional[str] = None,
+        other_type: Optional[str] = None,
     ) -> List[Relation]:
         """Get relations that connect sources and targets with the given node.
 
@@ -431,26 +430,24 @@ class Neo4jClient:
             Node namespace and identifier.
         relation :
             Relation type.
-        source_type :
-            Type constraint on the sources for in-edges
-        target_type :
-            Type constraint on the targets for out-edges
         node_type :
             Type constraint on the queried node itself
+        other_type :
+            Type constraint on the other node in the relation
 
         Returns
         -------
         rels :
             A list of relations matching the constraints.
         """
-        source_rels = self.get_source_relations(
-            target=node, relation=relation, source_type=source_type
+        rels = self.get_relations(
+            source=node,
+            relation=relation,
+            source_type=node_type,
+            target_type=other_type,
+            bidirectional=True,
         )
-        target_rels = self.get_target_relations(
-            source=node, relation=relation, target_type=target_type
-        )
-        all_rels = source_rels + target_rels
-        return all_rels
+        return rels
 
     @staticmethod
     def get_property_from_relations(relations: List[Relation], prop: str) -> Set[str]:

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -235,6 +235,7 @@ class Neo4jClient:
         source_type: Optional[str] = None,
         target_type: Optional[str] = None,
         limit: Optional[int] = None,
+        bidirectional: Optional[bool] = False,
     ) -> List[Relation]:
         """Return relations based on source, target and type constraints.
 
@@ -255,6 +256,9 @@ class Neo4jClient:
             A constraint on the target type
         limit :
             A limit on the number of relations returned.
+        bidirectional :
+            If True, return both directions of relationships
+            between the source and target.
 
         Returns
         -------
@@ -271,6 +275,7 @@ class Neo4jClient:
             relation_type=relation,
             target_id=target,
             target_type=target_type,
+            relation_direction=("both" if bidirectional else "right"),
         )
         query = """
             MATCH p=%s
@@ -416,6 +421,7 @@ class Neo4jClient:
         relation: Optional[str] = None,
         source_type: Optional[str] = None,
         target_type: Optional[str] = None,
+        node_type: Optional[str] = None,
     ) -> List[Relation]:
         """Get relations that connect sources and targets with the given node.
 
@@ -428,7 +434,9 @@ class Neo4jClient:
         source_type :
             Type constraint on the sources for in-edges
         target_type :
-            Type constraint on te targets for out-edges
+            Type constraint on the targets for out-edges
+        node_type :
+            Type constraint on the queried node itself
 
         Returns
         -------

--- a/src/indra_cogex/representation.py
+++ b/src/indra_cogex/representation.py
@@ -5,8 +5,17 @@
 
 __all__ = ["Node", "Relation", "indra_stmts_from_relations"]
 
-from typing import Any, Collection, Iterable, List, Mapping, Optional, Tuple, \
-    Dict, Union
+from typing import (
+    Any,
+    Collection,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Dict,
+    Union,
+)
 import json
 from indra.databases import identifiers
 from indra.ontology.standardize import standardize_name_db_refs
@@ -258,6 +267,7 @@ def triple_query(
     target_name: Optional[str] = None,
     target_type: Optional[str] = None,
     target_id: Optional[str] = None,
+    relation_direction: Optional[str] = "right",
 ) -> str:
     """Create a Cypher query from the given parameters.
 
@@ -279,17 +289,25 @@ def triple_query(
         The type of the target node. Optional.
     target_id :
         The identifier of the target node. Optional.
+    relation_direction :
+        The direction of the relation, one of 'left', 'right', or 'both'.
+        These correspond to <-[]-, -[]->, and -[]-, respectively.
 
     Returns
     -------
     :
         A Cypher query as a string.
     """
+    rel1, rel2 = "-", "-"
+    if relation_direction == "left":
+        rel1 = "<-"
+    elif relation_direction == "right":
+        rel2 = "->"
     source = node_query(node_name=source_name, node_type=source_type, node_id=source_id)
     # TODO could later make an alternate function for the relation
     relation = node_query(node_name=relation_name, node_type=relation_type)
     target = node_query(node_name=target_name, node_type=target_type, node_id=target_id)
-    return f"({source})-[{relation}]->({target})"
+    return f"({source}){rel1}[{relation}]{rel2}({target})"
 
 
 def node_query(


### PR DESCRIPTION
This PR optimizes and fixes a bug in the `get_all_relations` function. First `triple_query` is extended to allow different directions for the relation, then the `get_relations` function is extended with a `bidirectional` option. The `get_all_relations` query can then perform a single bidirectional query. This also fixes a bug where self-loops were retrieved twice, now these are only returned once. In addition, `get_all_relations` is refactored to be able to specify both the query node's and the other node's type which speeds up queries significantly. 