### PR TITLE
Assert column types

### DIFF
--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -276,5 +276,16 @@ def validate_relations(relations: Iterable[Relation]) -> Iterable[Relation]:
 def validate_headers(headers: Iterable[str]) -> None:
     """Check for data types in the headers"""
     for header in headers:
-        if ":" in header and header.split(":")[1] not in NEO4J_DATA_TYPES:
-            raise TypeError(f"Invalid header: {header}")
+        # If : is in the header and there is something after it check if
+        # it's a valid data type
+        if ":" in header and header.split(":")[1]:
+            dtype = header.split(":")[1]
+
+            # Strip trailing '[]' for array types
+            if dtype.endswith("[]"):
+                dtype = dtype[:-2]
+
+            if dtype not in NEO4J_DATA_TYPES:
+                raise TypeError(
+                    f"Invalid header data type '{dtype}' for header {header}"
+                )

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -262,7 +262,7 @@ def validate_nodes(nodes: Iterable[Node]) -> Iterable[Node]:
             continue
 
 
-def validate_relations(relations):
+def validate_relations(relations: Iterable[Relation]) -> Iterable[Relation]:
     for idx, rel in enumerate(relations):
         try:
             assert_valid_node(rel.source_ns, rel.source_id)

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -164,8 +164,10 @@ class Processor(ABC):
         metadata = sorted(set(key for node in nodes for key in node.data))
         try:
             validate_headers(metadata)
-        except ValueError as e:
-            raise ValueError(f"Bad edge data type in header for {self.name}") from e
+        except TypeError as e:
+            logger.error(f"Bad node data type in header for {self.name}")
+            raise e
+
         node_rows = (
             (
                 norm_id(node.db_ns, node.db_id),
@@ -208,8 +210,9 @@ class Processor(ABC):
         metadata = sorted(set(key for rel in rels for key in rel.data))
         try:
             validate_headers(metadata)
-        except ValueError as e:
-            raise ValueError(f"Bad edge data type in header for {self.name}") from e
+        except TypeError as e:
+            logger.error(f"Bad edge data type in header for {self.name}")
+            raise e
         edge_rows = (
             (
                 norm_id(rel.source_ns, rel.source_id),
@@ -274,4 +277,4 @@ def validate_headers(headers: Iterable[str]) -> None:
     """Check for data types in the headers"""
     for header in headers:
         if ":" in header and header.split(":")[1] not in NEO4J_DATA_TYPES:
-            raise ValueError(f"Invalid header: {header}")
+            raise TypeError(f"Invalid header: {header}")

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -60,7 +60,7 @@ NEO4J_DATA_TYPES = (
     # Used in relationship files
     "START_ID",
     "END_ID",
-    "TYPE"
+    "TYPE",
 )
 
 
@@ -157,8 +157,7 @@ class Processor(ABC):
             paths_by_type[node_type] = nodes_path
         return paths_by_type, dict(nodes_by_type)
 
-    def _dump_nodes_to_path(self, nodes, nodes_path, sample_path=None,
-                            write_mode="wt"):
+    def _dump_nodes_to_path(self, nodes, nodes_path, sample_path=None, write_mode="wt"):
         logger.info(f"Dumping into {nodes_path}...")
         nodes = list(validate_nodes(nodes))
         metadata = sorted(set(key for node in nodes for key in node.data))

--- a/tests/test_header_validation.py
+++ b/tests/test_header_validation.py
@@ -2,6 +2,29 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from indra_cogex.sources import Processor
 from indra_cogex.representation import Node, Relation
+from indra_cogex.sources.processor import validate_headers
+
+
+def test_validator():
+    # test the validator function
+    validate_headers(["myint:int"])
+    validate_headers(["myintarr:int[]"])
+
+    try:
+        validate_headers(["badint:integer"])
+    except Exception as e:
+        # Check correct error type and that type info is in the error message
+        assert isinstance(e, TypeError)
+        assert "badint" in str(e)
+        assert "integer" in str(e)
+
+    try:
+        validate_headers(["badintarr:integer[]"])
+    except Exception as e:
+        # Check correct error type and that type info is in the error message
+        assert isinstance(e, TypeError)
+        assert "badintarr" in str(e)
+        assert "integer[]" in str(e)
 
 
 class MockProcessor(Processor, object):

--- a/tests/test_header_validation.py
+++ b/tests/test_header_validation.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from indra_cogex.sources import Processor
+from indra_cogex.representation import Node, Relation
+
+
+class MockProcessor(Processor, object):
+    """A mock processor."""
+
+    name = "mock_processor"
+    node_types = ["mock_node"]
+    data_type: str = NotImplemented
+
+    def get_nodes(self):
+        """Return an empty sequence of nodes for testing."""
+        for n in range(3):
+            yield Node(
+                db_ns="PUBMED",
+                db_id=str(n),
+                labels=["MockNode"],
+                data={"an_int:int": n, f"raises_exception:{self.data_type}": n ** 2},
+            )
+
+    def get_relations(self):
+        """Return an empty sequence of relations for testing."""
+        num = 3
+        for n in range(num):
+            yield Relation(
+                source_ns="PUBMED",
+                source_id=str(n % num),
+                target_ns="PUBMED",
+                target_id=str(n + 1 % num),
+                rel_type="mock_relation",
+                data={"an_int:int": n, f"raises_exception:{self.data_type}": n ** 2},
+            )
+
+
+class BadProcessor(MockProcessor):
+    data_type = "bad_type"
+
+
+class GoodProcessor(MockProcessor):
+    data_type = "int"
+
+
+def test_data_type_validator():
+    with TemporaryDirectory() as temp_dir:
+        directory = Path(temp_dir)
+
+        processor_dir = directory / "output"
+        processor_dir.mkdir()
+
+        # override the __init_subclass__ with the directory for this test
+        MockProcessor.directory = directory
+        MockProcessor.nodes_path = directory / "nodes.tsv.gz"
+        MockProcessor.nodes_indra_path = directory / "nodes.pkl"
+        MockProcessor.edges_path = directory / "edges.tsv.gz"
+
+        mp = BadProcessor()
+        try:
+            mp.dump()
+        except Exception as e:
+            assert isinstance(e, TypeError)
+            assert "bad_type" in str(e)
+        else:
+            assert False, "Expected exception"
+
+
+def test_data_type_validator_good():
+    with TemporaryDirectory() as temp_dir:
+        directory = Path(temp_dir)
+
+        processor_dir = directory / "output"
+        processor_dir.mkdir()
+
+        # override the __init_subclass__ with the directory for this test
+        GoodProcessor.directory = directory
+        GoodProcessor.nodes_path = directory / "nodes.tsv.gz"
+        GoodProcessor.nodes_indra_path = directory / "nodes.pkl"
+        GoodProcessor.edges_path = directory / "edges.tsv.gz"
+
+        mp = GoodProcessor()
+        try:
+            mp.dump()
+        except Exception as e:
+            assert False, f"Unexpected exception: {repr(e)}"
+        else:
+            assert True

--- a/tests/test_header_validation.py
+++ b/tests/test_header_validation.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any
+
 from indra_cogex.sources import Processor
 from indra_cogex.representation import Node, Relation
 from indra_cogex.sources.processor import validate_headers
@@ -33,20 +35,27 @@ class MockProcessor(Processor, object):
     name = "mock_processor"
     node_types = ["mock_node"]
     data_type: str = NotImplemented
+    col_name: str = NotImplemented
+    num_nodes: int = 3
+
+    @staticmethod
+    def data_value(n: int) -> Any:
+        """Return a data value for the given node."""
+        raise NotImplementedError
 
     def get_nodes(self):
-        """Return an empty sequence of nodes for testing."""
-        for n in range(3):
+        """Return a sequence of nodes for testing."""
+        for n in range(self.num_nodes):
             yield Node(
                 db_ns="PUBMED",
                 db_id=str(n),
                 labels=["MockNode"],
-                data={"an_int:int": n, f"raises_exception:{self.data_type}": n ** 2},
+                data={f"{self.col_name}:{self.data_type}": self.data_value(n)},
             )
 
     def get_relations(self):
-        """Return an empty sequence of relations for testing."""
-        num = 3
+        """Return a sequence of relations for testing."""
+        num = self.num_nodes
         for n in range(num):
             yield Relation(
                 source_ns="PUBMED",
@@ -58,15 +67,45 @@ class MockProcessor(Processor, object):
             )
 
 
-class BadProcessor(MockProcessor):
+class BadTypeProcessor(MockProcessor):
     data_type = "bad_type"
+    col_name = "colname"
+
+    @staticmethod
+    def data_value(n: int) -> int:
+        return n ** 2
 
 
-class GoodProcessor(MockProcessor):
+class GoodTypeProcessor(MockProcessor):
     data_type = "int"
+    col_name = "colname"
+
+    @staticmethod
+    def data_value(n: int) -> int:
+        return n ** 2
 
 
-def test_data_type_validator():
+class BadArrayTypeProcessor(MockProcessor):
+    data_type = "bad_type[]"
+    col_name = "array_colname"
+
+    @staticmethod
+    def data_value(n: int) -> str:
+        m = int((n + 1) ** 2)
+        return f"[{';'.join(str(k) for k in range(m))}]"
+
+
+class GoodArrayTypeProcessor(MockProcessor):
+    data_type = "int[]"
+    col_name = "array_colname"
+
+    @staticmethod
+    def data_value(n: int) -> str:
+        m = int((n + 1) ** 2)
+        return f"[{';'.join(str(k) for k in range(m))}]"
+
+
+def test_data_type_validator_bad():
     with TemporaryDirectory() as temp_dir:
         directory = Path(temp_dir)
 
@@ -79,7 +118,7 @@ def test_data_type_validator():
         MockProcessor.nodes_indra_path = directory / "nodes.pkl"
         MockProcessor.edges_path = directory / "edges.tsv.gz"
 
-        mp = BadProcessor()
+        mp = BadTypeProcessor()
         try:
             mp.dump()
         except Exception as e:
@@ -97,15 +136,56 @@ def test_data_type_validator_good():
         processor_dir.mkdir()
 
         # override the __init_subclass__ with the directory for this test
-        GoodProcessor.directory = directory
-        GoodProcessor.nodes_path = directory / "nodes.tsv.gz"
-        GoodProcessor.nodes_indra_path = directory / "nodes.pkl"
-        GoodProcessor.edges_path = directory / "edges.tsv.gz"
+        GoodTypeProcessor.directory = directory
+        GoodTypeProcessor.nodes_path = directory / "nodes.tsv.gz"
+        GoodTypeProcessor.nodes_indra_path = directory / "nodes.pkl"
+        GoodTypeProcessor.edges_path = directory / "edges.tsv.gz"
 
-        mp = GoodProcessor()
+        mp = GoodTypeProcessor()
         try:
             mp.dump()
         except Exception as e:
             assert False, f"Unexpected exception: {repr(e)}"
+
+
+def test_array_data_type_validator_bad():
+    with TemporaryDirectory() as temp_dir:
+        directory = Path(temp_dir)
+
+        processor_dir = directory / "output"
+        processor_dir.mkdir()
+
+        # override the __init_subclass__ with the directory for this test
+        BadArrayTypeProcessor.directory = directory
+        BadArrayTypeProcessor.nodes_path = directory / "nodes.tsv.gz"
+        BadArrayTypeProcessor.nodes_indra_path = directory / "nodes.pkl"
+        BadArrayTypeProcessor.edges_path = directory / "edges.tsv.gz"
+
+        mp = BadArrayTypeProcessor()
+        try:
+            mp.dump()
+        except Exception as e:
+            assert isinstance(e, TypeError)
+            assert "bad_type[]" in str(e)
         else:
-            assert True
+            assert False, "Expected exception"
+
+
+def test_array_data_type_validator_good():
+    with TemporaryDirectory() as temp_dir:
+        directory = Path(temp_dir)
+
+        processor_dir = directory / "output"
+        processor_dir.mkdir()
+
+        # override the __init_subclass__ with the directory for this test
+        GoodArrayTypeProcessor.directory = directory
+        GoodArrayTypeProcessor.nodes_path = directory / "nodes.tsv.gz"
+        GoodArrayTypeProcessor.nodes_indra_path = directory / "nodes.pkl"
+        GoodArrayTypeProcessor.edges_path = directory / "edges.tsv.gz"
+
+        mp = GoodArrayTypeProcessor()
+        try:
+            mp.dump()
+        except Exception as e:
+            assert False, f"Unexpected exception: {repr(e)}"


### PR DESCRIPTION
This PR implements a check of tsv file headers so as to catch bad data types, e.g. `medscan_only:bool` instead of `medscan_only:boolean`.