### PR TITLE
Better unicode handling, remove xrefs from landing page counters

### DIFF
--- a/src/indra_cogex/apps/constants.py
+++ b/src/indra_cogex/apps/constants.py
@@ -17,7 +17,6 @@ edge_labels = {
     "expressed_in": "Gene Expressions",
     "copy_number_altered_in": "CNVs",
     "mutated_in": "Mutations",
-    "xref": "Xrefs",
     "partof": "Part Of",
     "has_trial": "Disease Trials",
     "isa": "Subclasses",

--- a/src/indra_cogex/apps/home/__init__.py
+++ b/src/indra_cogex/apps/home/__init__.py
@@ -44,7 +44,7 @@ def _figure_number(n: int):
 def home():
     """Render the home page."""
     node_counter, edge_counter = _get_counters()
-    ignore_labels = ["replaced_by"]
+    ignore_labels = ["replaced_by", "xrefs"]
     return render_template(
         "home.html",
         format_number=_figure_number,

--- a/src/indra_cogex/apps/home/__init__.py
+++ b/src/indra_cogex/apps/home/__init__.py
@@ -44,7 +44,7 @@ def _figure_number(n: int):
 def home():
     """Render the home page."""
     node_counter, edge_counter = _get_counters()
-    ignore_labels = ["replaced_by", "xrefs"]
+    ignore_labels = ["replaced_by", "xref"]
     return render_template(
         "home.html",
         format_number=_figure_number,

--- a/tests/test_web_service_helpers.py
+++ b/tests/test_web_service_helpers.py
@@ -10,7 +10,8 @@ from indra_cogex.apps.utils import unicode_escape, _stmt_to_row
 def test_unicode_double_escape():
     """Test unicode_double_escape function"""
     true_beta = "β"
-    double_escaped = r"\\u03b2"
+    single_escaped_beta = r"\u03b2"
+    double_escaped_beta = r"\\u03b2"
 
     true_alpha = "α"
     quadruple_escaped = r"\\\\u03b1"
@@ -19,12 +20,14 @@ def test_unicode_double_escape():
     true_alpha_and_beta = r"α and β"
 
     # Test with unicode
-    assert unicode_escape(double_escaped) == true_beta
+    assert unicode_escape(single_escaped_beta) == true_beta
+    assert unicode_escape(double_escaped_beta) == true_beta
     assert unicode_escape(quadruple_escaped) == true_alpha
     assert unicode_escape(unequal_escaped) == true_alpha_and_beta
 
     # Test with non-unicode
     assert unicode_escape("a") == "a"
+    assert unicode_escape("no unicode in here") == "no unicode in here"
 
 
 def test__stmt_to_row():

--- a/tests/test_web_service_helpers.py
+++ b/tests/test_web_service_helpers.py
@@ -4,7 +4,7 @@ Tests functionalities related to the CoGEx web service serving INDRA Discovery
 import json
 
 from indra.statements import Evidence, Agent, Activation
-from indra_cogex.apps.utils import unicode_double_escape, _stmt_to_row
+from indra_cogex.apps.utils import unicode_escape, _stmt_to_row
 
 
 def test_unicode_double_escape():
@@ -12,11 +12,19 @@ def test_unicode_double_escape():
     true_beta = "β"
     double_escaped = r"\\u03b2"
 
+    true_alpha = "α"
+    quadruple_escaped = r"\\\\u03b1"
+
+    unequal_escaped = r"\\\\u03b1 and \\u03b2"
+    true_alpha_and_beta = r"α and β"
+
     # Test with unicode
-    assert unicode_double_escape(double_escaped) == true_beta
+    assert unicode_escape(double_escaped) == true_beta
+    assert unicode_escape(quadruple_escaped) == true_alpha
+    assert unicode_escape(unequal_escaped) == true_alpha_and_beta
 
     # Test with non-unicode
-    assert unicode_double_escape("a") == "a"
+    assert unicode_escape("a") == "a"
 
 
 def test__stmt_to_row():


### PR DESCRIPTION
This PR updates the handling of unicode special characters with extra escaping that was previously giving mixed results for the front end rendering. The helper function dealing with the extra escapes now strips extra escapes of all lengths, even if there's a mixed number of escapes for different characters. As a result, when the unicode character is json dumped now, the JSON parser for the front end can correctly read the special characters (no update for the front end Vue code needed).

Tagging along to this PR is a small update that removes counts for `Xrefs` from the landing page.

Before PR (tested locally):
![image](https://user-images.githubusercontent.com/4621351/185686319-3505307d-2b59-403b-8839-60394f224817.png)
After PR (tested locally):
![image](https://user-images.githubusercontent.com/4621351/185686654-3194dd50-01c8-4e2b-9145-8d9b9557ca9b.png)