### PR TITLE
Add slimmed down meta subnetwork query

### DIFF
--- a/src/indra_cogex/apps/queries_web/__init__.py
+++ b/src/indra_cogex/apps/queries_web/__init__.py
@@ -70,7 +70,7 @@ SKIP_ARGUMENTS = {
 
 # This is the list of functions to be included
 module_functions = [(queries, fn) for fn in queries.__all__] + [
-    (subnetwork, fn) for fn in ["indra_subnetwork_relations"]
+    (subnetwork, fn) for fn in ["indra_subnetwork_relations", "indra_subnetwork_meta"]
 ]
 
 func_mapping = {fname: getattr(module, fname) for module, fname in module_functions}

--- a/src/indra_cogex/apps/queries_web/__main__.py
+++ b/src/indra_cogex/apps/queries_web/__main__.py
@@ -2,7 +2,7 @@
 
 """Run the query web app with ``python -m indra_cogex.apps.queries_web``."""
 
-from . import cli
+from indra_cogex.apps.queries_web.cli import cli
 
 if __name__ == "__main__":
     cli()

--- a/src/indra_cogex/client/subnetwork.py
+++ b/src/indra_cogex/client/subnetwork.py
@@ -49,6 +49,37 @@ def indra_subnetwork_relations(
 
 
 @autoclient()
+def indra_subnetwork_meta(
+    nodes: Iterable[Tuple[str, str]], *, client: Neo4jClient
+) -> List[List[str]]:
+    """Return the subnetwork induced by the given nodes as a set of Relations.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    nodes :
+        The nodes to query.
+
+    Returns
+    -------
+    :
+        The subnetwork induced by the given nodes represented as Relation
+        objects.
+    """
+    nodes_str = ", ".join(["'%s'" % norm_id(*node) for node in nodes])
+    query = """MATCH p=(n1:BioEntity)-[r:indra_rel]->(n2:BioEntity)
+            WHERE n1.id IN [%s]
+            AND n2.id IN [%s]
+            AND n1.id <> n2.id
+            RETURN n1.id, n2.id, r.stmt_type, r.stmt_hash, r.source_counts""" % (
+        nodes_str,
+        nodes_str,
+    )
+    return client.query_tx(query)
+
+
+@autoclient()
 def indra_subnetwork(
     nodes: Iterable[Tuple[str, str]], *, client: Neo4jClient
 ) -> List[Statement]:


### PR DESCRIPTION
This PR adds a version of the INDRA subnetwork query that only returns minimal metadata which makes the queries resolve much faster.