### PR TITLE
Fix source counts

### DIFF
--- a/src/indra_cogex/apps/utils.py
+++ b/src/indra_cogex/apps/utils.py
@@ -230,7 +230,6 @@ def format_stmts(
         row = _stmt_to_row(
             stmt,
             cur_dict=cur_dict,
-            evidence_counts=evidence_counts,
             cur_counts=cur_counts,
             remove_medscan=remove_medscan,
             source_counts=source_counts_per_hash.get(stmt.get_hash())
@@ -245,8 +244,8 @@ def format_stmts(
 
 def _stmt_to_row(
     stmt: Statement,
+    *,
     cur_dict,
-    evidence_counts,
     cur_counts,
     remove_medscan: bool = True,
     source_counts: Dict[str, int] = None,
@@ -291,11 +290,13 @@ def _stmt_to_row(
     else:
         sources = source_counts
 
-    # Remove medscan sources from the count if requested
-    if remove_medscan:
-        sources = {k: v for k, v in sources.items() if k != "medscan"}
+    # Remove medscan from the sources count and decrement the total count.
+    if remove_medscan and "medscan" in sources:
+        del sources["medscan"]
 
-    total_evidence = evidence_counts.get(hash_int, len(stmt.evidence))
+    # Calculate the total evidence as the sum of each of the sources' evidences
+    total_evidence = sum(sources.values())
+
     badges = [
         {
             "label": "evidence",

--- a/src/indra_cogex/apps/utils.py
+++ b/src/indra_cogex/apps/utils.py
@@ -81,6 +81,7 @@ def render_statements(
     evidence_lookup_time: Optional[float] = None,
     limit: Optional[int] = None,
     curations: Optional[List[Mapping[str, Any]]] = None,
+    source_counts_dict: Optional[Mapping[int, Mapping[str, int]]] = None,
     **kwargs,
 ) -> Response:
     """Render INDRA statements."""
@@ -94,6 +95,7 @@ def render_statements(
         limit=limit,
         curations=curations,
         remove_medscan=remove_medscan,
+        source_counts_per_hash=source_counts_dict,
     )
     end_time = time.time() - start_time
 

--- a/src/indra_cogex/apps/utils.py
+++ b/src/indra_cogex/apps/utils.py
@@ -84,7 +84,17 @@ def render_statements(
     source_counts_dict: Optional[Mapping[int, Mapping[str, int]]] = None,
     **kwargs,
 ) -> Response:
-    """Render INDRA statements."""
+    """Render INDRA statements.
+
+    Parameters
+    ----------
+    stmts:
+
+    evidence_counts:
+        Mapping from statement hash to total number of evidences
+    source_counts_dict :
+        Mapping from statement hash to dictionaries of source name to source counts
+    """
     _, _, user_email = resolve_email()
     remove_medscan = not bool(user_email)
 
@@ -157,7 +167,7 @@ def format_stmts(
     remove_medscan: bool = True,
     source_counts_per_hash: Optional[Dict[int, Dict[str, int]]] = None,
 ) -> List[StmtRow]:
-    """Format the statements for display
+    """Format the statements in the way that Patrick's Vue.js components expect.
 
     Wanted objects:
     - evidence: array of evidence json objects to be passed to <evidence>

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -4,6 +4,7 @@ import inspect
 import logging
 from functools import lru_cache, wraps
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
+import json
 
 import neo4j.graph
 from indra.config import get_config
@@ -94,6 +95,13 @@ class Neo4jClient:
     def query_dict(self, query: str) -> Dict:
         """Run a read-only query that generates a dictionary."""
         return dict(self.query_tx(query))
+
+    def query_dict_value_json(self, query: str) -> Dict:
+        """Run a read-only query that generates a dictionary."""
+        return {
+            key: json.loads(j)
+            for key, j in self.query_tx(query)
+        }
 
     def query_tx(
         self, query: str, squeeze: bool = False

--- a/tests/test_web_service_helpers.py
+++ b/tests/test_web_service_helpers.py
@@ -45,12 +45,10 @@ def test__stmt_to_row():
     a = Agent("a")
     b = Agent("b")
     db_stmt = Activation(a, b, evidence=[db_ev])
-    stmt_hash = db_stmt.get_hash()
     source_counts = {"biopax": 1}
     ev_array, english, stmt_hash, sources, total_evidence, badges, = _stmt_to_row(
         stmt=db_stmt,
         cur_dict={},
-        evidence_counts={stmt_hash: 1},
         cur_counts={},
         source_counts=source_counts,
         include_belief_badge=True,


### PR DESCRIPTION
This PR fixes a discrepancy in the source counts vs the evidence counts that was due to the source count information not being passed along from the relation meta data for various calls to the DB in the curator module.

This update also:
- ensures that source counts and evidence counts are updated together when dealing with removing medscan evidence.
- adds a new query helper method in the client for queries where the resulting data output is of the form `[(<hashable>, <json string>), ...]` and can be cast as a dict of the form `{<hashable>: <json>}`