### PR TITLE
Extend enrichment with custom background gene sets

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ install_requires =
     statsmodels
     pandas
     python-dateutil
+    zenodo-client<0.3
 
 include_package_data = True
 python_requires = >=3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,6 @@ install_requires =
     statsmodels
     pandas
     python-dateutil
-    zenodo-client<0.3
 
 include_package_data = True
 python_requires = >=3.7

--- a/src/indra_cogex/client/enrichment/discrete.py
+++ b/src/indra_cogex/client/enrichment/discrete.py
@@ -2,7 +2,7 @@
 
 """A collection of analyses possible on gene lists (of HGNC identifiers)."""
 
-from typing import Iterable, List, Mapping, Optional, Set, Tuple
+from typing import Collection, Iterable, List, Mapping, Optional, Set, Tuple
 
 import numpy as np
 import pandas as pd
@@ -186,7 +186,7 @@ def _do_ora(
 def go_ora(
     client: Neo4jClient,
     gene_ids: Iterable[str],
-    background_gene_ids: Optional[Iterable[str]] = None,
+    background_gene_ids: Optional[Collection[str]] = None,
     **kwargs,
 ) -> pd.DataFrame:
     """Calculate over-representation on all GO terms.
@@ -220,7 +220,7 @@ def go_ora(
 def wikipathways_ora(
     client: Neo4jClient,
     gene_ids: Iterable[str],
-    background_gene_ids: Optional[Iterable[str]] = None,
+    background_gene_ids: Optional[Collection[str]] = None,
     **kwargs,
 ) -> pd.DataFrame:
     """Calculate over-representation on all WikiPathway pathways.
@@ -256,7 +256,7 @@ def wikipathways_ora(
 def reactome_ora(
     client: Neo4jClient,
     gene_ids: Iterable[str],
-    background_gene_ids: Optional[Iterable[str]] = None,
+    background_gene_ids: Optional[Collection[str]] = None,
     **kwargs,
 ) -> pd.DataFrame:
     """Calculate over-representation on all Reactome pathways.
@@ -290,7 +290,7 @@ def reactome_ora(
 @autoclient()
 def phenotype_ora(
     gene_ids: Iterable[str],
-    background_gene_ids: Optional[Iterable[str]] = None,
+    background_gene_ids: Optional[Collection[str]] = None,
     *,
     client: Neo4jClient,
     **kwargs,
@@ -328,7 +328,7 @@ def phenotype_ora(
 def indra_downstream_ora(
     client: Neo4jClient,
     gene_ids: Iterable[str],
-    background_gene_ids: Optional[Iterable[str]] = None,
+    background_gene_ids: Optional[Collection[str]] = None,
     *,
     minimum_evidence_count: Optional[int] = 1,
     minimum_belief: Optional[float] = 0.0,
@@ -381,7 +381,7 @@ def indra_downstream_ora(
 def indra_upstream_ora(
     client: Neo4jClient,
     gene_ids: Iterable[str],
-    background_gene_ids: Optional[Iterable[str]] = None,
+    background_gene_ids: Optional[Collection[str]] = None,
     *,
     minimum_evidence_count: Optional[int] = 1,
     minimum_belief: Optional[float] = 0.0,

--- a/src/indra_cogex/client/enrichment/discrete.py
+++ b/src/indra_cogex/client/enrichment/discrete.py
@@ -109,7 +109,6 @@ def gene_ontology_single_ora(
     client: Neo4jClient,
     go_term: Tuple[str, str],
     gene_ids: List[str],
-
 ) -> float:
     """Get the *p*-value for the Fisher exact test a given GO term.
 
@@ -188,7 +187,7 @@ def go_ora(
     client: Neo4jClient,
     gene_ids: Iterable[str],
     background_gene_ids: Optional[Iterable[str]] = None,
-    **kwargs
+    **kwargs,
 ) -> pd.DataFrame:
     """Calculate over-representation on all GO terms.
 
@@ -210,8 +209,11 @@ def go_ora(
         DataFrame with columns:
         curie, name, p, q, mlp, mlq
     """
-    count = count_human_genes(client=client) if not background_gene_ids \
+    count = (
+        count_human_genes(client=client)
+        if not background_gene_ids
         else len(background_gene_ids)
+    )
     return _do_ora(get_go(client=client), query=gene_ids, count=count, **kwargs)
 
 
@@ -219,7 +221,7 @@ def wikipathways_ora(
     client: Neo4jClient,
     gene_ids: Iterable[str],
     background_gene_ids: Optional[Iterable[str]] = None,
-    **kwargs
+    **kwargs,
 ) -> pd.DataFrame:
     """Calculate over-representation on all WikiPathway pathways.
 
@@ -241,8 +243,11 @@ def wikipathways_ora(
         DataFrame with columns:
         curie, name, p, q, mlp, mlq
     """
-    count = count_human_genes(client=client) if not background_gene_ids \
+    count = (
+        count_human_genes(client=client)
+        if not background_gene_ids
         else len(background_gene_ids)
+    )
     return _do_ora(
         get_wikipathways(client=client), query=gene_ids, count=count, **kwargs
     )
@@ -252,7 +257,7 @@ def reactome_ora(
     client: Neo4jClient,
     gene_ids: Iterable[str],
     background_gene_ids: Optional[Iterable[str]] = None,
-    **kwargs
+    **kwargs,
 ) -> pd.DataFrame:
     """Calculate over-representation on all Reactome pathways.
 
@@ -274,8 +279,11 @@ def reactome_ora(
         DataFrame with columns:
         curie, name, p, q, mlp, mlq
     """
-    count = count_human_genes(client=client) if not background_gene_ids \
+    count = (
+        count_human_genes(client=client)
+        if not background_gene_ids
         else len(background_gene_ids)
+    )
     return _do_ora(get_reactome(client=client), query=gene_ids, count=count, **kwargs)
 
 
@@ -285,7 +293,7 @@ def phenotype_ora(
     background_gene_ids: Optional[Iterable[str]] = None,
     *,
     client: Neo4jClient,
-    **kwargs
+    **kwargs,
 ) -> pd.DataFrame:
     """Calculate over-representation on all HP phenotypes.
 
@@ -307,8 +315,11 @@ def phenotype_ora(
         DataFrame with columns:
         curie, name, p, q, mlp, mlq
     """
-    count = count_human_genes(client=client) if not background_gene_ids \
+    count = (
+        count_human_genes(client=client)
+        if not background_gene_ids
         else len(background_gene_ids)
+    )
     return _do_ora(
         get_phenotype_gene_sets(client=client), query=gene_ids, count=count, **kwargs
     )
@@ -350,8 +361,11 @@ def indra_downstream_ora(
         DataFrame with columns:
         curie, name, p, q, mlp, mlq
     """
-    count = count_human_genes(client=client) if not background_gene_ids \
+    count = (
+        count_human_genes(client=client)
+        if not background_gene_ids
         else len(background_gene_ids)
+    )
     return _do_ora(
         get_entity_to_regulators(
             client=client,
@@ -400,8 +414,11 @@ def indra_upstream_ora(
         DataFrame with columns:
         curie, name, p, q, mlp, mlq
     """
-    count = count_human_genes(client=client) if not background_gene_ids \
+    count = (
+        count_human_genes(client=client)
+        if not background_gene_ids
         else len(background_gene_ids)
+    )
     return _do_ora(
         get_entity_to_targets(
             client=client,

--- a/src/indra_cogex/client/enrichment/discrete.py
+++ b/src/indra_cogex/client/enrichment/discrete.py
@@ -54,16 +54,16 @@ def _prepare_hypergeometric_test(
     Parameters
     ----------
     query_set:
-        gene set to test against pathway
+        Input gene set to test against a target set (e.g., a pathway).
     target_set:
-        pathway gene set
+        The target gene set (e.g., a pathway).
     universe_size:
-        number of HGNC symbols
+        Size of the background gene set.
 
     Returns
     -------
     :
-        A 2x2 matrix
+        A 2x2 matrix used as input for Fisher's exact test.
     """
     return np.array(
         [
@@ -96,6 +96,7 @@ def count_human_genes(*, client: Neo4jClient) -> int:
     query = """\
         MATCH (n:BioEntity)
         WHERE n.id STARTS WITH 'hgnc'
+        AND NOT n.obsolete = "True"
         RETURN count(n) as count
     """
     results = client.query_tx(query)
@@ -105,7 +106,10 @@ def count_human_genes(*, client: Neo4jClient) -> int:
 
 
 def gene_ontology_single_ora(
-    client: Neo4jClient, go_term: Tuple[str, str], gene_ids: List[str]
+    client: Neo4jClient,
+    go_term: Tuple[str, str],
+    gene_ids: List[str],
+
 ) -> float:
     """Get the *p*-value for the Fisher exact test a given GO term.
 
@@ -180,7 +184,12 @@ def _do_ora(
     return df
 
 
-def go_ora(client: Neo4jClient, gene_ids: Iterable[str], **kwargs) -> pd.DataFrame:
+def go_ora(
+    client: Neo4jClient,
+    gene_ids: Iterable[str],
+    background_gene_ids: Optional[Iterable[str]] = None,
+    **kwargs
+) -> pd.DataFrame:
     """Calculate over-representation on all GO terms.
 
     Parameters
@@ -189,6 +198,9 @@ def go_ora(client: Neo4jClient, gene_ids: Iterable[str], **kwargs) -> pd.DataFra
         Neo4jClient
     gene_ids :
         List of HGNC gene identifiers
+    background_gene_ids :
+        List of HGNC gene identifiers for the background gene set. If not
+        given, all genes with HGNC IDs are used as the background.
     **kwargs :
         Additional keyword arguments to pass to _do_ora
 
@@ -198,12 +210,16 @@ def go_ora(client: Neo4jClient, gene_ids: Iterable[str], **kwargs) -> pd.DataFra
         DataFrame with columns:
         curie, name, p, q, mlp, mlq
     """
-    count = count_human_genes(client=client)
+    count = count_human_genes(client=client) if not background_gene_ids \
+        else len(background_gene_ids)
     return _do_ora(get_go(client=client), query=gene_ids, count=count, **kwargs)
 
 
 def wikipathways_ora(
-    client: Neo4jClient, gene_ids: Iterable[str], **kwargs
+    client: Neo4jClient,
+    gene_ids: Iterable[str],
+    background_gene_ids: Optional[Iterable[str]] = None,
+    **kwargs
 ) -> pd.DataFrame:
     """Calculate over-representation on all WikiPathway pathways.
 
@@ -213,6 +229,9 @@ def wikipathways_ora(
         Neo4jClient
     gene_ids :
         List of HGNC gene identifiers
+    background_gene_ids :
+        List of HGNC gene identifiers for the background gene set. If not
+        given, all genes with HGNC IDs are used as the background.
     **kwargs :
         Additional keyword arguments to pass to _do_ora
 
@@ -222,14 +241,18 @@ def wikipathways_ora(
         DataFrame with columns:
         curie, name, p, q, mlp, mlq
     """
-    count = count_human_genes(client=client)
+    count = count_human_genes(client=client) if not background_gene_ids \
+        else len(background_gene_ids)
     return _do_ora(
         get_wikipathways(client=client), query=gene_ids, count=count, **kwargs
     )
 
 
 def reactome_ora(
-    client: Neo4jClient, gene_ids: Iterable[str], **kwargs
+    client: Neo4jClient,
+    gene_ids: Iterable[str],
+    background_gene_ids: Optional[Iterable[str]] = None,
+    **kwargs
 ) -> pd.DataFrame:
     """Calculate over-representation on all Reactome pathways.
 
@@ -239,6 +262,9 @@ def reactome_ora(
         Neo4jClient
     gene_ids :
         List of HGNC gene identifiers
+    background_gene_ids :
+        List of HGNC gene identifiers for the background gene set. If not
+        given, all genes with HGNC IDs are used as the background.
     **kwargs :
         Additional keyword arguments to pass to _do_ora
 
@@ -248,13 +274,18 @@ def reactome_ora(
         DataFrame with columns:
         curie, name, p, q, mlp, mlq
     """
-    count = count_human_genes(client=client)
+    count = count_human_genes(client=client) if not background_gene_ids \
+        else len(background_gene_ids)
     return _do_ora(get_reactome(client=client), query=gene_ids, count=count, **kwargs)
 
 
 @autoclient()
 def phenotype_ora(
-    gene_ids: Iterable[str], *, client: Neo4jClient, **kwargs
+    gene_ids: Iterable[str],
+    background_gene_ids: Optional[Iterable[str]] = None,
+    *,
+    client: Neo4jClient,
+    **kwargs
 ) -> pd.DataFrame:
     """Calculate over-representation on all HP phenotypes.
 
@@ -262,6 +293,9 @@ def phenotype_ora(
     ----------
     gene_ids :
         List of HGNC gene identifiers
+    background_gene_ids :
+        List of HGNC gene identifiers for the background gene set. If not
+        given, all genes with HGNC IDs are used as the background.
     client :
         Neo4jClient
     **kwargs :
@@ -273,7 +307,8 @@ def phenotype_ora(
         DataFrame with columns:
         curie, name, p, q, mlp, mlq
     """
-    count = count_human_genes(client=client)
+    count = count_human_genes(client=client) if not background_gene_ids \
+        else len(background_gene_ids)
     return _do_ora(
         get_phenotype_gene_sets(client=client), query=gene_ids, count=count, **kwargs
     )
@@ -282,6 +317,7 @@ def phenotype_ora(
 def indra_downstream_ora(
     client: Neo4jClient,
     gene_ids: Iterable[str],
+    background_gene_ids: Optional[Iterable[str]] = None,
     *,
     minimum_evidence_count: Optional[int] = 1,
     minimum_belief: Optional[float] = 0.0,
@@ -298,6 +334,9 @@ def indra_downstream_ora(
         Neo4jClient
     gene_ids :
         List of HGNC gene identifiers
+    background_gene_ids :
+        List of HGNC gene identifiers for the background gene set. If not
+        given, all genes with HGNC IDs are used as the background.
     minimum_evidence_count :
         Minimum number of evidences to consider a causal relationship
     minimum_belief :
@@ -311,7 +350,8 @@ def indra_downstream_ora(
         DataFrame with columns:
         curie, name, p, q, mlp, mlq
     """
-    count = count_human_genes(client=client)
+    count = count_human_genes(client=client) if not background_gene_ids \
+        else len(background_gene_ids)
     return _do_ora(
         get_entity_to_regulators(
             client=client,
@@ -327,6 +367,7 @@ def indra_downstream_ora(
 def indra_upstream_ora(
     client: Neo4jClient,
     gene_ids: Iterable[str],
+    background_gene_ids: Optional[Iterable[str]] = None,
     *,
     minimum_evidence_count: Optional[int] = 1,
     minimum_belief: Optional[float] = 0.0,
@@ -343,6 +384,9 @@ def indra_upstream_ora(
         Neo4jClient
     gene_ids :
         List of HGNC gene identifiers
+    background_gene_ids :
+        List of HGNC gene identifiers for the background gene set. If not
+        given, all genes with HGNC IDs are used as the background.
     minimum_evidence_count :
         Minimum number of evidences to consider a causal relationship
     minimum_belief :
@@ -356,7 +400,8 @@ def indra_upstream_ora(
         DataFrame with columns:
         curie, name, p, q, mlp, mlq
     """
-    count = count_human_genes(client=client)
+    count = count_human_genes(client=client) if not background_gene_ids \
+        else len(background_gene_ids)
     return _do_ora(
         get_entity_to_targets(
             client=client,

--- a/src/indra_cogex/client/enrichment/utils.py
+++ b/src/indra_cogex/client/enrichment/utils.py
@@ -7,7 +7,17 @@ import pickle
 from collections import defaultdict
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, DefaultDict, Dict, Iterable, Mapping, Optional, Set, Tuple, TypeVar
+from typing import (
+    Any,
+    DefaultDict,
+    Dict,
+    Iterable,
+    Mapping,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+)
 
 import pystow
 from indra.databases.identifiers import get_ns_id_from_identifiers
@@ -231,8 +241,11 @@ def collect_genes_with_confidence(
     # We now apply filtering to the background gene set if necessary
     if background_gene_ids:
         for curie_key, hgnc_dict in res.items():
-            res[curie_key] = {hgnc_id: v for k, v in hgnc_dict.items()
-                              if hgnc_id in background_gene_ids}
+            res[curie_key] = {
+                hgnc_id: v
+                for hgnc_id, v in hgnc_dict.items()
+                if hgnc_id in background_gene_ids
+            }
     return res
 
 
@@ -276,9 +289,7 @@ def get_go(
 
 @autoclient()
 def get_wikipathways(
-    *,
-    background_gene_ids: Optional[Iterable[str]] = None,
-    client: Neo4jClient
+    *, background_gene_ids: Optional[Iterable[str]] = None, client: Neo4jClient
 ) -> Dict[Tuple[str, str], Set[str]]:
     """Get WikiPathways gene sets.
 
@@ -305,16 +316,16 @@ def get_wikipathways(
     """
     )
     return collect_gene_sets(
-        client=client, query=query, cache_file=WIKIPATHWAYS_GENE_SET_PATH,
-        background_gene_ids=background_gene_ids
+        client=client,
+        query=query,
+        cache_file=WIKIPATHWAYS_GENE_SET_PATH,
+        background_gene_ids=background_gene_ids,
     )
 
 
 @autoclient()
 def get_reactome(
-    *,
-    background_gene_ids: Optional[Iterable[str]] = None,
-    client: Neo4jClient
+    *, background_gene_ids: Optional[Iterable[str]] = None, client: Neo4jClient
 ) -> Dict[Tuple[str, str], Set[str]]:
     """Get Reactome gene sets.
 
@@ -341,16 +352,16 @@ def get_reactome(
     """
     )
     return collect_gene_sets(
-        client=client, query=query, cache_file=REACTOME_GENE_SETS_PATH,
-        background_gene_ids=background_gene_ids
+        client=client,
+        query=query,
+        cache_file=REACTOME_GENE_SETS_PATH,
+        background_gene_ids=background_gene_ids,
     )
 
 
 @autoclient()
 def get_phenotype_gene_sets(
-    *,
-    background_gene_ids: Optional[Iterable[str]] = None,
-    client: Neo4jClient
+    *, background_gene_ids: Optional[Iterable[str]] = None, client: Neo4jClient
 ) -> Dict[Tuple[str, str], Set[str]]:
     """Get HPO phenotype gene sets.
 
@@ -377,8 +388,11 @@ def get_phenotype_gene_sets(
     """
     )
     return collect_gene_sets(
-        client=client, query=query, cache_file=HPO_GENE_SETS_PATH,
-        background_gene_ids=background_gene_ids)
+        client=client,
+        query=query,
+        cache_file=HPO_GENE_SETS_PATH,
+        background_gene_ids=background_gene_ids,
+    )
 
 
 def filter_gene_set_confidences(
@@ -447,8 +461,10 @@ def get_entity_to_targets(
     """
     )
     genes_with_confidence = collect_genes_with_confidence(
-        client=client, query=query, cache_file=TO_TARGETS_GENE_SETS_PATH,
-        background_gene_ids=background_gene_ids
+        client=client,
+        query=query,
+        cache_file=TO_TARGETS_GENE_SETS_PATH,
+        background_gene_ids=background_gene_ids,
     )
     return filter_gene_set_confidences(
         genes_with_confidence,
@@ -503,8 +519,10 @@ def get_entity_to_regulators(
     """
     )
     genes_with_confidence = collect_genes_with_confidence(
-        client=client, query=query, cache_file=TO_REGULATORS_GENE_SETS_PATH,
-        background_gene_ids=background_gene_ids
+        client=client,
+        query=query,
+        cache_file=TO_REGULATORS_GENE_SETS_PATH,
+        background_gene_ids=background_gene_ids,
     )
     return filter_gene_set_confidences(
         genes_with_confidence,

--- a/src/indra_cogex/client/enrichment/utils.py
+++ b/src/indra_cogex/client/enrichment/utils.py
@@ -206,7 +206,10 @@ def collect_genes_with_confidence(
         curie_to_hgnc_ids = defaultdict(dict)
         max_beliefs: Dict[Tuple[str, str, str], float] = {}
         max_ev_counts: Dict[Tuple[str, str, str], int] = {}
-        for result in client.query_tx(query):
+        query_res = client.query_tx(query)
+        if query_res is None:
+            raise RuntimeError
+        for result in query_res:
             curie = result[0]
             name = result[1]
             hgnc_ids = set()

--- a/src/indra_cogex/client/enrichment/utils.py
+++ b/src/indra_cogex/client/enrichment/utils.py
@@ -245,6 +245,7 @@ def get_go(
     query = dedent(
         """\
         MATCH (gene:BioEntity)-[:associated_with]->(term:BioEntity)
+        WHERE NOT gene.obsolete = "True"
         RETURN term.id, term.name, collect(gene.id) as gene_curies;
     """
     )
@@ -276,6 +277,7 @@ def get_wikipathways(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set[str]]:
         """\
         MATCH (pathway:BioEntity)-[:haspart]->(gene:BioEntity)
         WHERE pathway.id STARTS WITH "wikipathways" and gene.id STARTS WITH "hgnc"
+        AND NOT gene.obsolete = "True"
         RETURN pathway.id, pathway.name, collect(gene.id);
     """
     )
@@ -303,6 +305,7 @@ def get_reactome(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set[str]]:
         """\
         MATCH (pathway:BioEntity)-[:haspart]-(gene:BioEntity)
         WHERE pathway.id STARTS WITH "reactome" and gene.id STARTS WITH "hgnc"
+        AND NOT gene.obsolete = "True"
         RETURN pathway.id, pathway.name, collect(gene.id);
     """
     )
@@ -330,6 +333,7 @@ def get_phenotype_gene_sets(*, client: Neo4jClient) -> Dict[Tuple[str, str], Set
         """\
         MATCH (s:BioEntity)-[:phenotype_has_gene]-(gene:BioEntity)
         WHERE s.id STARTS WITH "hp" and gene.id STARTS WITH "hgnc"
+        AND NOT gene.obsolete = "True"
         RETURN s.id, s.name, collect(gene.id);
     """
     )
@@ -388,6 +392,7 @@ def get_entity_to_targets(
         MATCH (regulator:BioEntity)-[r:indra_rel]->(gene:BioEntity)
         WHERE
             gene.id STARTS WITH "hgnc"                  // Collecting human genes only
+            AND NOT gene.obsolete = "True"              // Skip obsolete
             AND r.stmt_type <> "Complex"                // Ignore complexes since they are non-directional
             AND NOT regulator.id STARTS WITH "uniprot"  // This is a simple way to ignore non-human proteins
         RETURN
@@ -438,6 +443,7 @@ def get_entity_to_regulators(
         MATCH (gene:BioEntity)-[r:indra_rel]->(target:BioEntity)
         WHERE
             gene.id STARTS WITH "hgnc"               // Collecting human genes only
+            AND NOT gene.obsolete = "True"           // Skip obsolete
             AND r.stmt_type <> "Complex"             // Ignore complexes since they are non-directional
             AND NOT target.id STARTS WITH "uniprot"  // This is a simple way to ignore non-human proteins
         RETURN
@@ -504,6 +510,7 @@ def _query(
         WHERE gene.id STARTS WITH "hgnc"                // Collecting human genes only
             AND r.stmt_type in [{query_range}]          // Ignore complexes since they are non-directional
             AND NOT regulator.id STARTS WITH "uniprot"  // This is a simple way to ignore non-human proteins
+            AND NOT gene.obsolete = "True"              // Skip obsolete
             {evidence_line}
             {belief_line}
         RETURN 

--- a/src/indra_cogex/client/enrichment/utils.py
+++ b/src/indra_cogex/client/enrichment/utils.py
@@ -128,8 +128,10 @@ def collect_gene_sets(
 
     # We now apply filtering to the background gene set if necessary
     if background_gene_ids:
-        for k, v in res.items():
-            res[k] = {vv for vv in v if vv in background_gene_ids}
+        for curie_key, hgnc_ids in res.items():
+            res[curie_key] = {
+                hgnc_id for hgnc_id in hgnc_ids if hgnc_id in background_gene_ids
+            }
 
     return res
 

--- a/src/indra_cogex/client/enrichment/utils.py
+++ b/src/indra_cogex/client/enrichment/utils.py
@@ -576,6 +576,7 @@ def _query(
 def get_positive_stmt_sets(
     *,
     client: Neo4jClient,
+    background_gene_ids: Optional[Iterable[str]] = None,
     minimum_evidence_count: Optional[int] = 1,
     minimum_belief: Optional[float] = 0.0,
 ) -> Dict[Tuple[str, str], Set[str]]:
@@ -587,6 +588,9 @@ def get_positive_stmt_sets(
     ----------
     client :
         The Neo4j client.
+    background_gene_ids :
+        List of HGNC gene identifiers for the background gene set. If not
+        given, all genes with HGNC IDs are used as the background.
     minimum_evidence_count :
         The minimum number of evidences for a relationship.
         Defaults to 1 (i.e., cutoff not applied.
@@ -605,6 +609,7 @@ def get_positive_stmt_sets(
             query=_query(POSITIVE_STMT_TYPES),
             client=client,
             cache_file=POSITIVES_GENE_SETS_PATH,
+            background_gene_ids=background_gene_ids,
         ),
         minimum_belief=minimum_belief,
         minimum_evidence_count=minimum_evidence_count,
@@ -615,6 +620,7 @@ def get_positive_stmt_sets(
 def get_negative_stmt_sets(
     *,
     client: Neo4jClient,
+    background_gene_ids: Optional[Iterable[str]] = None,
     minimum_evidence_count: Optional[int] = 1,
     minimum_belief: Optional[float] = 0.0,
 ) -> Dict[Tuple[str, str], Set[str]]:
@@ -626,6 +632,9 @@ def get_negative_stmt_sets(
     ----------
     client :
         The Neo4j client.
+    background_gene_ids :
+        List of HGNC gene identifiers for the background gene set. If not
+        given, all genes with HGNC IDs are used as the background.
     minimum_evidence_count :
         The minimum number of evidences for a relationship.
         Defaults to 1 (i.e., cutoff not applied.
@@ -644,6 +653,7 @@ def get_negative_stmt_sets(
             query=_query(NEGATIVE_STMT_TYPES),
             client=client,
             cache_file=NEGATIVES_GENE_SETS_PATH,
+            background_gene_ids=background_gene_ids,
         ),
         minimum_belief=minimum_belief,
         minimum_evidence_count=minimum_evidence_count,


### PR DESCRIPTION
This PR allows calling various enrichment functions with custom background gene sets. It also fixes an issue with handling the default background gene sets (all HGNC IDs) where obsolete IDs were also counted turning out to cause a non-negligible increase in gene counts.

Since the enrichment functions and corresponding utility functions are quite complex at this point, it would be great if we could find a way to unit test these. A blunt option would be to just test them as is, which would run some relatively large queries on the service but would otherwise work. Another option is to pre-produce some cached files and pull them for testing (the disadvantage being that only part of the code will be invoked if caching is used). Yet another option would be to mock the neo4j client, and have functions like `get_go` return some minimal test data structure in the context of each test (here the only disadvantage is that we aren't testing the content of the graph directly). @cthoyt what do you think?