### PR TITLE
Use separate sessions

### DIFF
--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -83,15 +83,10 @@ class Neo4jClient:
         query_params :
             Parameters associated with the query.
         """
-        # todo: redo this to use `with ... as tx:` contexts like for query_tx
-        tx = self.get_session().begin_transaction()
-        try:
-            tx.run(query, parameters=query_params)
-            tx.commit()
-        except Exception as e:
-            logger.error(e)
-        finally:
-            tx.close()
+        with self.driver.session() as session:
+            with session.begin_transaction() as tx:
+                tx.run(query, parameters=query_params)
+                tx.commit()
 
     def query_dict(self, query: str) -> Dict:
         """Run a read-only query that generates a dictionary."""

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -69,6 +69,12 @@ class Neo4jClient:
             max_connection_lifetime=3 * 60,
         )
 
+    def __del__(self):
+        # Safely shut down the driver as a Neo4jClient object is garbage collected
+        # https://neo4j.com/docs/api/python-driver/current/api.html#driver-object-lifetime
+        if self.driver is not None:
+            self.driver.close()
+
     def create_tx(
         self,
         query: str,

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -1102,7 +1102,4 @@ def do_cypher_tx(
         query_params: Optional[Dict] = None
 ) -> List[List]:
     result = tx.run(query, parameters=query_params)
-    values = []
-    for record in result:
-        values.append(record.values())
-    return values
+    return [record.values() for record in result]

--- a/tests/test_autoclient.py
+++ b/tests/test_autoclient.py
@@ -49,7 +49,6 @@ def test_autoclient():
     client = Neo4jClient()
     tissues = get_tissues_for_gene(("HGNC", "9896"), client=client)
     _check_tissues(tissues)
-    assert client.session is not None
 
 
 def _check_tissues(tissues):


### PR DESCRIPTION
This PR implements separate sessions per query to the database in `query_tx`, just like in [MIRA](https://github.com/indralab/mira/pull/66).

I recreated the transaction error by running the web service locally and submitting large amounts of requests from two separate terminals to the service and verified that the same action did not reproduce the error after the update.

~Left to do~
~The second method in the client, `create_tx`, that also does transactions outside a session context is used for [indexing](https://github.com/bgyori/indra_cogex/blob/main/src/indra_cogex/client/neo4j_client.py#L920-L980) and I have not yet tested that to feel confident enough to replace its current implementation.~

`Neo4jClient.query_tx` _and_ `Neo4jClient.create_tx` _are now implemented using_ `Session.read_transaction` _and_ `Session.write_transaction`, _respectively. This prohibits write transactions when using_ `Neo4jClient.query_tx`.