### PR TITLE
Handle invalid MeSH IDs from ClincalTrials

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install tox
-          BIOONTOLOGY_VERSION=1.27
+          BIOONTOLOGY_VERSION=1.28
           echo "bio ontology version: ${BIOONTOLOGY_VERSION}"
           mkdir -p $HOME/.indra/bio_ontology/$BIOONTOLOGY_VERSION
           wget -nv https://bigmech.s3.amazonaws.com/travis/bio_ontology/$BIOONTOLOGY_VERSION/mock_ontology.pkl -O $HOME/.indra/bio_ontology/$BIOONTOLOGY_VERSION/bio_ontology.pkl

--- a/tests/test_clinicaltrials.py
+++ b/tests/test_clinicaltrials.py
@@ -1,4 +1,5 @@
-from indra_cogex.sources.clinicaltrials import ClinicaltrialsProcessor
+from indra_cogex.sources.clinicaltrials import ClinicaltrialsProcessor, \
+    get_correct_mesh_id
 import os
 
 
@@ -35,3 +36,9 @@ def test_get_relations():
         assert relation.target_ns == "CLINICALTRIALS"
         assert relation.target_id
         assert relation.rel_type == "has_trial" or relation.rel_type == "tested_in"
+
+
+def test_get_correct_mesh_id():
+    assert get_correct_mesh_id('D013274') == 'D013274'
+    assert get_correct_mesh_id('D000013274') == 'D013274'
+    assert get_correct_mesh_id('C000603933', 'Osimertinib') == 'C000596361'


### PR DESCRIPTION
I discovered that most MeSH IDs provided by the ClincalTrials API are invalid (reported this to their support). There are 3 main reasons for this:
1. Widespread invalid zero-padding of IDs e.g., D000013274 instead of the valid D013274.
2. Invalid IDs that cannot be fixed via zero-padding changes. It turns out, however, that Gilda can ground the corresponding MeSH term strings to recover these IDs. Some of these turn out to use recent term names that are only available in the 2022 MeSH release which Gilda now integrates.
3. Invalid IDs that have corresponding term names provided that are also invalid in a way that grounding them doesn't yield any results. There is actually only 1 instance of this currently, where ClinicalTrials provides an invalid MeSH ID along with a synonym that is non-exact (i.e., not even listed as an exact synonym) wrt the concept instead of its standard name.