### PR TITLE
Speed up mesh child terms query

### DIFF
--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -1109,32 +1109,12 @@ def _get_mesh_child_terms(
     #  for the query below
     query = (
         """
-        MATCH p=(c:BioEntity)-[:isa|partof*1..]->(:BioEntity {id: "%s"})
-        RETURN p
+        MATCH (c:BioEntity)-[:isa|partof*1..]->(:BioEntity {id: "%s"})
+        RETURN DISTINCT c.id
     """
         % meshid_norm
     )
-    paths = client.query_tx(query, squeeze=True)
-    relations_list = [client.neo4j_to_relations(p) for p in paths]
-    mesh_ids = set()
-    for path_result in relations_list:
-        current_set = set()
-        for relation in path_result:
-            # Check if relation is 'isa' and if both nodes are mesh nodes
-            if relation.rel_type == "isa" and \
-                    relation.source_ns.lower() == "mesh" and\
-                    relation.target_ns.lower() == "mesh":
-                current_set.add(norm_id(relation.source_ns, relation.source_id))
-                current_set.add(norm_id(relation.target_ns, relation.target_id))
-            else:
-                # This path result contains a relation with something else
-                # than a mesh-[:isa]->mesh relation: reset the current set
-                # and continue to next path result
-                current_set = set()
-                break
-        mesh_ids |= current_set
-    # Remove the queried mesh id
-    return mesh_ids - {meshid_norm}
+    return set(client.query_tx(query, squeeze=True))
 
 
 @autoclient(cache=True)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -7,6 +7,7 @@ from indra_cogex.client.queries import *
 from indra_cogex.client.queries import (
     _filter_out_medscan_evidence,
     _get_ev_dict_from_hash_ev_query,
+    _get_mesh_child_terms,
 )
 from indra_cogex.representation import Node
 
@@ -223,6 +224,25 @@ def test_isa_or_partof():
     term = ("MESH", "D020263")
     parent = ("MESH", "D007855")
     assert isa_or_partof(term, parent, client=client)
+
+
+@pytest.mark.nonpublic
+def test_get_mesh_child_terms_empty():
+    client = _get_client()
+    term = ("MESH", "D015002")
+    child_terms = _get_mesh_child_terms(term, client=client)
+    assert isinstance(child_terms, set)
+    assert child_terms == set()
+
+
+@pytest.mark.nonpublic
+def test_get_mesh_child_terms_nonempty():
+    client = _get_client()
+    term = ("MESH", "D007855")
+    child_terms = _get_mesh_child_terms(term, client=client)
+    assert isinstance(child_terms, set)
+    assert len(child_terms) > 0
+    assert list(child_terms)[0].startswith("mesh:")
 
 
 @pytest.mark.nonpublic


### PR DESCRIPTION
This PR resolves #122. The slow part has been identified to be querying for mesh child terms over more than one hop while only using `isa` a relationship type. One query for one of the tests runs for 340 seconds in this case.

For some (still unclear) reason, querying using `-[:isa|partof*1..]->` is about _170x faster_ :exploding_head:  than using just using `-[:isa*1..]->`, regardless if the result is empty or not when using the below query structure:

```
MATCH (c:BioEntity)-[:<rel expr>]->(:BioEntity {id: "mesh:<mesh id>"})
RETURN c.id
```
Below is a table detailing the rough timing in seconds for the above query using different values for `mesh id` and `rel expr`:

| `<rel expr>` | D015002 (has no children) | D007855 (1 direct child and 2 indirect children) |
|---:|---|---|
| `isa` | 0.4 | 0.4 |
| `isa*1..` | ***342*** | ***342*** |
| `isa/partof` | 1.6 | 1.7 |
| `isa/partof*1..` | 2.0 | 2.0 |
| `partof/isa` | 1.6 | 1.7 |
| `partof/isa*1..` | 2.0 | 2.0 |

The changes in this PR makes use of this and changes the relation in the query from `:isa*1..` to `:partof|isa*1..` with some post filtering that takes a negligible amount of time.