### PR TITLE
New source: InterPro Domains

### DIFF
--- a/docs/source/modules/sources/index.rst
+++ b/docs/source/modules/sources/index.rst
@@ -15,6 +15,7 @@ INDRA CoGEx Sources
    goa
    indra_db
    indra_ontology
+   interpro
    odinson/index
    pathways
    pubmed

--- a/docs/source/modules/sources/interpro.rst
+++ b/docs/source/modules/sources/interpro.rst
@@ -1,0 +1,4 @@
+InterPro Processor (:py:mod:`indra_cogex.sources.interpro`)
+===========================================================
+.. automodule:: indra_cogex.sources.interpro
+    :members:

--- a/src/indra_cogex/representation.py
+++ b/src/indra_cogex/representation.py
@@ -3,7 +3,7 @@
 """Representations for nodes and relations to upload to Neo4j."""
 
 
-__all__ = ["Node", "Relation", "indra_stmts_from_relations"]
+__all__ = ["Node", "Relation", "indra_stmts_from_relations", "norm_id"]
 
 import codecs
 from typing import (

--- a/src/indra_cogex/sources/__init__.py
+++ b/src/indra_cogex/sources/__init__.py
@@ -13,14 +13,15 @@ from .cbioportal import (
 from .chembl import ChemblIndicationsProcessor
 from .clinicaltrials import ClinicaltrialsProcessor
 from .goa import GoaProcessor
+from .hpoa import HpDiseasePhenotypeProcessor, HpPhenotypeGeneProcessor
 from .indra_db import DbProcessor, EvidenceProcessor
 from .indra_ontology import OntologyProcessor
+from .interpro import InterproProcessor
+from .nih_reporter import NihReporterProcessor
 from .pathways import ReactomeProcessor, WikipathwaysProcessor
 from .processor import Processor
 from .pubmed import PubmedProcessor
 from .sider import SIDERSideEffectProcessor
-from .hpoa import HpDiseasePhenotypeProcessor, HpPhenotypeGeneProcessor
-from .nih_reporter import NihReporterProcessor
 
 __all__ = [
     "processor_resolver",
@@ -41,7 +42,8 @@ __all__ = [
     "PubmedProcessor",
     "HpDiseasePhenotypeProcessor",
     "HpPhenotypeGeneProcessor",
-    "NihReporterProcessor"
+    "NihReporterProcessor",
+    "InterproProcessor",
 ]
 
 processor_resolver = Resolver.from_subclasses(Processor)

--- a/src/indra_cogex/sources/interpro/__init__.py
+++ b/src/indra_cogex/sources/interpro/__init__.py
@@ -65,12 +65,12 @@ class InterproProcessor(Processor):
     def get_nodes(self):  # noqa:D102
         unique_go = set()
         unique_hgnc = set()
-        for interpro_id, interpro_type, name, short_name in self.entries_df.values:
+        for interpro_id, _type, name, short_name in self.entries_df.values:
             yield Node(
                 "interpro",
                 interpro_id,
                 ["BioEntity"],
-                dict(name=name, short_name=short_name, type=interpro_type),
+                dict(name=name, short_name=short_name),
             )
             unique_go.update(self.interpro_to_goa.get(interpro_id, set()))
             unique_hgnc.update(self.interpro_to_genes.get(interpro_id, set()))

--- a/src/indra_cogex/sources/interpro/__init__.py
+++ b/src/indra_cogex/sources/interpro/__init__.py
@@ -76,7 +76,7 @@ class InterproProcessor(Processor):
         unique_hgnc = set()
         for interpro_id, _type, name, short_name in self.entries_df.values:
             yield Node(
-                "interpro",
+                "IP",
                 interpro_id,
                 ["BioEntity"],
                 dict(name=name, short_name=short_name, version=self.version),
@@ -95,21 +95,21 @@ class InterproProcessor(Processor):
         for interpro_id in sorted(self.interpro_ids):
             for child_interpro_id in sorted(self.parents.get(interpro_id, set())):
                 yield Relation(
-                    "interpro", child_interpro_id, "interpro", interpro_id, "isa"
+                    "IP", child_interpro_id, "IP", interpro_id, "isa"
                 )
 
             for go_id in sorted(self.interpro_to_goa.get(interpro_id, [])):
-                yield Relation("interpro", interpro_id, "GO", go_id, "associated_with")
+                yield Relation("IP", interpro_id, "GO", go_id, "associated_with")
 
             for hgnc_id, start, end in sorted(
                 self.interpro_to_genes.get(interpro_id, []), key=lambda t: int(t[0])
             ):
                 yield Relation(
-                    "interpro",
-                    interpro_id,
                     "HGNC",
                     hgnc_id,
-                    "has_member",
+                    "IP",
+                    interpro_id,
+                    "has_domain",
                     {"start:int": start, "end:int": end, "version": self.version},
                 )
 

--- a/src/indra_cogex/sources/interpro/__init__.py
+++ b/src/indra_cogex/sources/interpro/__init__.py
@@ -2,6 +2,8 @@
 
 """Processor for the InterPro database.
 
+This was added in https://github.com/bgyori/indra_cogex/pull/125.
+
 .. seealso:: https://ftp.ebi.ac.uk/pub/databases/interpro/current_release/
 """
 
@@ -19,6 +21,10 @@ from tqdm import tqdm
 
 from ..processor import Processor
 from ...representation import Node, Relation
+
+__all__ = [
+    "InterproProcessor",
+]
 
 logger = logging.getLogger(__name__)
 

--- a/src/indra_cogex/sources/interpro/__init__.py
+++ b/src/indra_cogex/sources/interpro/__init__.py
@@ -1,0 +1,248 @@
+# -*- coding: utf-8 -*-
+
+"""Processor for the InterPro database.
+
+.. seealso:: https://ftp.ebi.ac.uk/pub/databases/interpro/current_release/
+"""
+
+import gzip
+import logging
+from collections import defaultdict
+from typing import Iterable, List, Mapping, Set, Tuple
+
+import pandas as pd
+import pystow
+from protmapper import uniprot_client
+from tqdm import tqdm
+
+from ..processor import Processor
+from ...representation import Node, Relation
+
+logger = logging.getLogger(__name__)
+
+INTERPRO_ENTRIES_URL = (
+    "ftp://ftp.ebi.ac.uk/pub/databases/interpro/current_release/entry.list"
+)
+INTERPRO_SHORT_NAMES_URL = (
+    "ftp://ftp.ebi.ac.uk/pub/databases/interpro/current_release/short_names.dat"
+)
+INTERPRO_TREE_URL = (
+    "ftp://ftp.ebi.ac.uk/pub/databases/interpro/current_release/ParentChildTreeFile.txt"
+)
+INTERPRO_PROTEINS_URL = (
+    "ftp://ftp.ebi.ac.uk/pub/databases/interpro/current_release/protein2ipr.dat.gz"
+)
+INTERPRO_GO_URL = (
+    "ftp://ftp.ebi.ac.uk/pub/databases/interpro/current_release/interpro2go"
+)
+
+
+class InterproProcessor(Processor):
+    """Processor for Interpro."""
+
+    name = "interpro"
+    node_types = ["BioEntity"]
+
+    def __init__(self, force: bool = False):
+        """Initialize the InterPro processor."""
+        self.entries_df = get_entries_df(module=self.module)
+        self.interpro_ids = set(self.entries_df["ENTRY_AC"])
+        self.parents = get_parent_to_children(force=force, module=self.module)
+        self.interpro_to_goa = get_interpro_to_goa(force=force, module=self.module)
+
+        interpro_to_proteins = get_interpro_to_proteins(
+            force=force, interpro_ids=self.interpro_ids, module=self.module
+        )
+        interpro_to_genes = defaultdict(set)
+        for interpro_id, uniprot_ids in interpro_to_proteins.items():
+            for uniprot_id in uniprot_ids:
+                hgnc_id = uniprot_client.get_hgnc_id(uniprot_id)
+                if hgnc_id is not None:
+                    # there are a lot of TrEMBL entries, these will return none
+                    interpro_to_genes[interpro_id].add(hgnc_id)
+        self.interpro_to_genes = dict(interpro_to_genes)
+
+    def get_nodes(self):  # noqa:D102
+        unique_go = set()
+        unique_hgnc = set()
+        for interpro_id, interpro_type, name, short_name in self.entries_df.values:
+            yield Node(
+                "interpro",
+                interpro_id,
+                ["BioEntity"],
+                dict(name=name, short_name=short_name, type=interpro_type),
+            )
+            unique_go.update(self.interpro_to_goa.get(interpro_id, set()))
+            unique_hgnc.update(self.interpro_to_genes.get(interpro_id, set()))
+        for go_id in sorted(unique_go):
+            yield Node("GO", go_id, ["BioEntity"])
+        for hgnc_id in sorted(unique_hgnc, key=int):
+            yield Node("HGNC", hgnc_id, ["BioEntity"])
+
+    def get_relations(self):  # noqa:D102
+        for interpro_id in self.interpro_ids:
+            for child_interpro_id in self.parents.get(interpro_id, []):
+                yield Relation(
+                    "interpro", child_interpro_id, "interpro", interpro_id, "isa"
+                )
+
+            for go_id in self.interpro_to_goa.get(interpro_id, []):
+                yield Relation("interpro", interpro_id, "GO", go_id, "associated_with")
+
+            for hgnc_id in self.interpro_to_genes.get(interpro_id, []):
+                yield Relation("interpro", interpro_id, "HGNC", hgnc_id, "has_member")
+
+
+def get_entries_df(*, force: bool = False, module: pystow.Module) -> pd.DataFrame:
+    """Get a dataframe of InterPro entries, filtered to domains."""
+    short_names_df = module.ensure_csv(
+        url=INTERPRO_SHORT_NAMES_URL,
+        read_csv_kwargs=dict(
+            header=None,
+            names=("ENTRY_AC", "ENTRY_SHORT_NAME"),
+        ),
+        force=force,
+    )
+
+    df = module.ensure_csv(
+        url=INTERPRO_ENTRIES_URL,
+        read_csv_kwargs=dict(
+            skiprows=1,
+            names=("ENTRY_AC", "ENTRY_TYPE", "ENTRY_NAME"),
+        ),
+        force=force,
+    )
+    # Filter to entry types that represent domains
+    df = df[df["ENTRY_TYPE"] == "Domain"]
+    df = df.merge(short_names_df, on="ENTRY_AC", how="left")
+    return df
+
+
+def get_parent_to_children(
+    *, force: bool = False, module: pystow.Module
+) -> Mapping[str, List[str]]:
+    """The a mapping from parent InterPro ID to list of children InterPro IDs."""
+    path = module.ensure(url=INTERPRO_TREE_URL, force=force)
+    with open(path) as file:
+        return _parse_tree_helper(file)
+
+
+def _parse_tree_helper(lines: Iterable[str]) -> Mapping[str, List[str]]:
+    child_to_parents = defaultdict(list)
+    previous_depth, previous_id = 0, None
+    stack = [previous_id]
+
+    for line in tqdm(lines, desc="parsing InterPro tree"):
+        depth = _count_leading_dashes(line)
+        parent_id, _ = line[depth:].split("::", 1)
+
+        if depth == 0:
+            stack.clear()
+            stack.append(parent_id)
+        else:
+            if depth > previous_depth:
+                stack.append(previous_id)
+
+            elif depth < previous_depth:
+                del stack[-1]
+
+            child_id = stack[-1]
+            child_to_parents[child_id].append(parent_id)  # type:ignore
+
+        previous_depth, previous_id = depth, parent_id
+
+    parent_to_children = defaultdict(list)
+    for child_id, parent_ids in child_to_parents.items():
+        for parent_id in parent_ids:
+            parent_to_children[parent_id].append(child_id)
+    return dict(parent_to_children)
+
+
+def _count_leading_dashes(s: str) -> int:
+    """Count the number of leading dashes on a string."""
+    for position, element in enumerate(s):
+        if element != "-":
+            return position
+    raise ValueError
+
+
+def get_interpro_to_proteins(
+    *, force: bool = False, interpro_ids, module: pystow.Module
+) -> Mapping[str, Set[str]]:
+    """Get a mapping from InterPro identifiers to a set of UniProt identifiers."""
+    cache_path = module.join(name="protein2ipr_human.tsv")
+
+    if cache_path.is_file():
+        interpro_to_uniprots = defaultdict(set)
+        with cache_path.open() as file:
+            for line in file:
+                interpro_id, uniprot_id = line.strip().split("\t", 1)
+                interpro_to_uniprots[interpro_id].add(uniprot_id)
+        return dict(interpro_to_uniprots)
+
+    path = module.ensure(url=INTERPRO_PROTEINS_URL, force=force)
+    interpro_to_uniprots = defaultdict(set)
+    with gzip.open(path, "rt") as file:
+        for line in tqdm(
+            file,
+            unit_scale=True,
+            unit="line",
+            desc="Processing ipr2protein",
+            total=1_216_508_710,
+        ):
+            uniprot_id, interpro_id, _ = line.split("\t", 2)
+            if interpro_id not in interpro_ids:
+                continue
+            if uniprot_client.is_human(uniprot_id):
+                interpro_to_uniprots[interpro_id].add(uniprot_id)
+
+    interpro_to_uniprots = dict(interpro_to_uniprots)
+
+    with cache_path.open("w") as file:
+        for interpro_id, uniprot_ids in tqdm(
+            sorted(interpro_to_uniprots.items()),
+            unit_scale=True,
+            desc="Writing human subset",
+        ):
+            for uniprot_id in sorted(uniprot_ids):
+                print(interpro_id, uniprot_id, sep="\t", file=file)
+
+    return interpro_to_uniprots
+
+
+def get_interpro_to_goa(
+    *, force: bool = False, module: pystow.Module
+) -> Mapping[str, Set[str]]:
+    """Get a mapping from InterPro identifiers to sets of GO id/name pairs.."""
+    path = module.ensure(url=INTERPRO_GO_URL, name="interpro2go.tsv", force=force)
+    interpro_to_go_annotations = defaultdict(set)
+    with path.open() as file:
+        for line in file:
+            line = line.strip()
+            if line[0] == "!":
+                continue
+            interpro_id, go_id = process_go_mapping_line(line)
+            interpro_to_go_annotations[interpro_id].add(go_id)
+    return dict(interpro_to_go_annotations)
+
+
+def process_go_mapping_line(line: str) -> Tuple[str, str]:
+    """Process a GO mapping file line.
+
+    Example lines:
+
+    .. code-block::
+
+        !date: 2022/10/05 11:07:08
+        !Mapping of InterPro entries to GO
+        !external resource: http://www.ebi.ac.uk/interpro
+        !citation: Blum et al. (2021) Nucl. Acids Res. 49:D344â€“D354
+        !contact:interhelp@ebi.ac.uk!
+        InterPro:IPR000003 Retinoid X receptor/HNF4 > GO:DNA binding ; GO:0003677
+        InterPro:IPR000003 Retinoid X receptor/HNF4 > GO:nuclear steroid receptor activity ; GO:0003707
+    """
+    line = line[len("InterPro:") :]
+    line, go_id = (part.strip() for part in line.rsplit(";", 1))
+    line, _go_name = (part.strip() for part in line.rsplit(">", 1))
+    interpro_id, _interpro_name = (part.strip() for part in line.split(" ", 1))
+    return interpro_id, go_id

--- a/src/indra_cogex/sources/interpro/__init__.py
+++ b/src/indra_cogex/sources/interpro/__init__.py
@@ -8,7 +8,8 @@
 import gzip
 import logging
 from collections import defaultdict
-from typing import Iterable, List, Mapping, Set, Tuple
+from pathlib import Path
+from typing import Iterable, List, Mapping, Optional, Set, Tuple
 
 import pandas as pd
 import pystow
@@ -211,10 +212,16 @@ def get_interpro_to_proteins(
 
 
 def get_interpro_to_goa(
-    *, force: bool = False, module: pystow.Module
+    *,
+    force: bool = False,
+    module: Optional[pystow.Module] = None,
+    path: Optional[Path] = None,
 ) -> Mapping[str, Set[str]]:
     """Get a mapping from InterPro identifiers to sets of GO id/name pairs.."""
-    path = module.ensure(url=INTERPRO_GO_URL, name="interpro2go.tsv", force=force)
+    if path is None:
+        if module is None:
+            raise ValueError
+        path = module.ensure(url=INTERPRO_GO_URL, name="interpro2go.tsv", force=force)
     interpro_to_go_annotations = defaultdict(set)
     with path.open() as file:
         for line in file:

--- a/src/indra_cogex/sources/interpro/__init__.py
+++ b/src/indra_cogex/sources/interpro/__init__.py
@@ -96,7 +96,7 @@ class InterproProcessor(Processor):
                 yield Relation("interpro", interpro_id, "GO", go_id, "associated_with")
 
             for hgnc_id, start, end in sorted(
-                self.interpro_to_genes.get(interpro_id, []), key=int
+                self.interpro_to_genes.get(interpro_id, []), key=lambda t: int(t[0])
             ):
                 yield Relation(
                     "interpro",

--- a/src/indra_cogex/sources/interpro/__main__.py
+++ b/src/indra_cogex/sources/interpro/__main__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+"""Run the InterPro processor using ``python -m indra_cogex.sources.interpro``."""
+
+from . import InterproProcessor
+
+if __name__ == "__main__":
+    InterproProcessor.cli()

--- a/tests/resources/test_interpro_go.txt
+++ b/tests/resources/test_interpro_go.txt
@@ -1,0 +1,7 @@
+!date: 2022/10/05 11:07:08
+!Mapping of InterPro entries to GO
+!external resource: http://www.ebi.ac.uk/interpro
+!citation: Blum et al. (2021) Nucl. Acids Res. 49:D344â€“D354
+!contact:interhelp@ebi.ac.uk!
+InterPro:IPR000003 Retinoid X receptor/HNF4 > GO:DNA binding ; GO:0003677
+InterPro:IPR000003 Retinoid X receptor/HNF4 > GO:nuclear steroid receptor activity ; GO:0003707

--- a/tests/resources/test_interpro_protein.tsv
+++ b/tests/resources/test_interpro_protein.tsv
@@ -1,0 +1,10 @@
+P10636	IPR004839	Aminotransferase, class I/classII	PF00155	41	381
+P10636	IPR010961	Tetrapyrrole biosynthesis, 5-aminolevulinic acid synthase	TIGR01821	12	391
+P10636	IPR015421	Pyridoxal phosphate-dependent transferase, major domain	G3DSA:3.40.640.10	48	288
+P10636	IPR015422	Pyridoxal phosphate-dependent transferase, small domain	G3DSA:3.90.1150.10	36	378
+P10636	IPR015424	Pyridoxal phosphate-dependent transferase	SSF53383	9	389
+P10636	IPR003439	ABC transporter-like, ATP-binding domain	PF00005	361	504
+P10636	IPR003439	ABC transporter-like, ATP-binding domain	PS50893	344	573
+P10636	IPR003593	AAA+ ATPase domain	SM00382	369	550
+P10636	IPR011527	ABC transporter type 1, transmembrane domain	PF00664	20	276
+P10636	IPR011527	ABC transporter type 1, transmembrane domain	PS50929	17	289

--- a/tests/resources/test_interpro_tree.txt
+++ b/tests/resources/test_interpro_tree.txt
@@ -1,0 +1,6 @@
+IPR000053::Thymidine/pyrimidine-nucleoside phosphorylase::
+--IPR013466::Thymidine phosphorylase/AMP phosphorylase::
+----IPR017713::AMP phosphorylase::
+----IPR028579::Putative thymidine phosphorylase::
+--IPR018090::Pyrimidine-nucleoside phosphorylase, bacterial/eukaryotic::
+----IPR013465::Thymidine phosphorylase::

--- a/tests/test_sources/__init__.py
+++ b/tests/test_sources/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for INDRA CoGEx sources."""

--- a/tests/test_sources/test_interpro.py
+++ b/tests/test_sources/test_interpro.py
@@ -1,0 +1,20 @@
+import unittest
+from pathlib import Path
+
+from indra_cogex.sources.interpro import get_interpro_to_goa, process_go_mapping_line
+
+HERE = Path(__file__).parent.resolve()
+RESOURCES = HERE.parent.joinpath("resources").resolve()
+
+
+class TestInterpro(unittest.TestCase):
+    """Test case for InterPro."""
+
+    def test_go_mapping_line(self):
+        line = "InterPro:IPR000003 Retinoid X receptor/HNF4 > GO:DNA binding ; GO:0003677"
+        self.assertEqual(("IPR000003", "GO:0003677"), process_go_mapping_line(line))
+
+    def test_go_mapping(self):
+        path = RESOURCES.joinpath("test_interpro_go.txt")
+        data = get_interpro_to_goa(path=path)
+        self.assertEqual({"IPR000003": {"GO:0003677", "GO:0003707"}}, data)

--- a/tests/test_sources/test_interpro.py
+++ b/tests/test_sources/test_interpro.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from indra_cogex.sources.interpro import (
     _help_parent_to_children,
+    _read_ipr2protein,
     get_interpro_to_goa,
     process_go_mapping_line,
 )
@@ -15,7 +16,9 @@ class TestInterpro(unittest.TestCase):
     """Test case for InterPro."""
 
     def test_go_mapping_line(self):
-        line = "InterPro:IPR000003 Retinoid X receptor/HNF4 > GO:DNA binding ; GO:0003677"
+        line = (
+            "InterPro:IPR000003 Retinoid X receptor/HNF4 > GO:DNA binding ; GO:0003677"
+        )
         self.assertEqual(("IPR000003", "GO:0003677"), process_go_mapping_line(line))
 
     def test_go_mapping(self):
@@ -46,3 +49,13 @@ class TestInterpro(unittest.TestCase):
         self.assertNotIn("IPR028579", set(parent_to_children))
         self.assertNotIn("IPR017713", set(parent_to_children))
         self.assertNotIn("IPR013465", set(parent_to_children))
+
+    def test_proteins(self):
+        path = RESOURCES.joinpath("test_interpro_protein.tsv")
+        interpro_ids = {"IPR004839", "IPR003439", "IPR011527"}
+        with path.open() as file:
+            interpro_to_proteins = _read_ipr2protein(file, interpro_ids)
+
+        self.assertNotIn("IPR015421", interpro_to_proteins)
+        self.assertIn("IPR011527", interpro_to_proteins)
+        self.assertIn(("P10636", 20, 276), interpro_to_proteins["IPR011527"])

--- a/tests/test_sources/test_interpro.py
+++ b/tests/test_sources/test_interpro.py
@@ -1,7 +1,11 @@
 import unittest
 from pathlib import Path
 
-from indra_cogex.sources.interpro import get_interpro_to_goa, process_go_mapping_line
+from indra_cogex.sources.interpro import (
+    _help_parent_to_children,
+    get_interpro_to_goa,
+    process_go_mapping_line,
+)
 
 HERE = Path(__file__).parent.resolve()
 RESOURCES = HERE.parent.joinpath("resources").resolve()
@@ -18,3 +22,27 @@ class TestInterpro(unittest.TestCase):
         path = RESOURCES.joinpath("test_interpro_go.txt")
         data = get_interpro_to_goa(path=path)
         self.assertEqual({"IPR000003": {"GO:0003677", "GO:0003707"}}, data)
+
+    def test_parse_tree(self):
+        path = RESOURCES.joinpath("test_interpro_tree.txt")
+        with path.open() as file:
+            parent_to_children = _help_parent_to_children(file)
+
+        # Root term
+        self.assertIn("IPR000053", set(parent_to_children))
+        self.assertEqual(
+            {"IPR013466", "IPR018090"},
+            parent_to_children["IPR000053"],
+        )
+
+        # Middle term
+        self.assertIn("IPR013466", set(parent_to_children))
+        self.assertEqual(
+            {"IPR017713", "IPR028579"},
+            parent_to_children["IPR013466"],
+        )
+
+        # Leaves shouldn't be included
+        self.assertNotIn("IPR028579", set(parent_to_children))
+        self.assertNotIn("IPR017713", set(parent_to_children))
+        self.assertNotIn("IPR013465", set(parent_to_children))


### PR DESCRIPTION
This PR imports InterPro entries corresponding to protein domains along with the following relationships for each:

1. `isa` relationships in the InterPro domain hierarchy
2. `has_member` relationships pointing to human proteins (only ones that were mappable via ProtMapper)
3. `associated` relationships to gene ontology terms

<details>
<summary>code to check hierarchical redundancies</summary>

```python
from indra_cogex.sources.interpro import InterproProcessor

proc = InterproProcessor()
proc

c = 0
t = 0
for parent, children in proc.parents.items():
    parent_genes = {gene for gene, _, _ in proc.interpro_to_genes.get(parent, [])}
    if not parent_genes:
        continue
    for child in children:
        child_genes = {gene for gene, _, _ in proc.interpro_to_genes.get(child, [])}
        if not child_genes:
            continue
        
        intersection = parent_genes.intersection(child_genes)
        union = parent_genes.union(child_genes)
        c += 1
        overlap = intersection == child_genes
        t += overlap
        if not overlap:
            print(parent,child, len(child_genes), len(intersection))
        
print(f"{t:,} full intersection ({t/c:.1%}), {c-t:,} missing {(c-t)/c:.1%}")
```

</details>