### PR TITLE
Fix belief bug

### DIFF
--- a/src/indra_cogex/sources/indra_db/assembly.py
+++ b/src/indra_cogex/sources/indra_db/assembly.py
@@ -341,49 +341,50 @@ def belief_calc(refinements_graph: nx.DiGraph):
     # Store hash: belief score
     belief_scores = {}
 
+    def _get_support_evidence_for_stmt(stmt_hash: int) -> List[Evidence]:
+        # Find all the statements that refine the current
+        # statement, i.e. all the statements that are more
+        # specific than the current statement => look for ancestors
+        # then add up all the source counts for the statement
+        # itself and the statements that refine it
+        summed_source_counts = Counter(source_counts[stmt_hash])
+
+        # If there are refinements, add them to the source counts
+        if stmt_hash in refinements_graph.nodes():
+            refiner_hashes = nx.ancestors(G=refinements_graph,
+                                          source=stmt_hash)
+            for refiner_hash in refiner_hashes:
+                summed_source_counts += Counter(source_counts[refiner_hash])
+
+        # Mock evidence - todo: add annotations?
+        # Add evidence objects for each source's count and each source
+        ev_list = []
+        for source, count in summed_source_counts.items():
+            for _ in range(count):
+                ev_list.append(Evidence(source_api=source))
+        return ev_list
+
     # Iterate over each unique statement
     with gzip.open(unique_stmts_fname.as_posix(), "rt") as fh:
         reader = csv.reader(fh, delimiter="\t")
 
         for _ in tqdm.tqdm(range(num_batches), desc="Calculating belief"):
-            stmts = []
+            stmt_batch = []
             for _ in range(batch_size):
                 try:
-                    sh, sjs = next(reader)
+                    shs, sjs = next(reader)
                     stmt = stmt_from_json(
                         load_statement_json(sjs, remove_evidence=True)
                     )
-                    this_hash = int(sh)
-
-                    # Find all the statements that refine the current
-                    # statement, i.e. all the statements that are more
-                    # specific than the current statement => look for ancestors
-                    # then add up all the source counts for the statement
-                    # itself and the statements that refine it
-                    summed_source_counts = Counter(source_counts[this_hash])
-
-                    # If there are refinements, add them to the source counts
-                    if this_hash in refinements_graph.nodes():
-                        refiner_hashes = nx.ancestors(
-                            G=refinements_graph, source=this_hash
-                        )
-                        for refiner_hash in refiner_hashes:
-                            summed_source_counts += Counter(source_counts[refiner_hash])
-
-                    # Mock evidence - todo: add annotations?
-                    ev_list = []
-                    for source, count in summed_source_counts.items():
-                        # Add `count` evidence objects for each source
-                        for _ in range(count):
-                            ev_list.append(Evidence(source_api=source))
-                    stmt.evidence = ev_list
-                    stmts.append((this_hash, stmt))
+                    this_hash = int(shs)
+                    stmt.evidence = _get_support_evidence_for_stmt(this_hash)
+                    stmt_batch.append((this_hash, stmt))
 
                 except StopIteration:
                     break
 
             # Belief calculation for this batch
-            hashes, stmt_list = zip(*stmts)
+            hashes, stmt_list = zip(*stmt_batch)
             be.set_prior_probs(statements=stmt_list)
             for sh, st in zip(hashes, stmt_list):
                 belief_scores[sh] = st.belief

--- a/src/indra_cogex/sources/indra_db/assembly.py
+++ b/src/indra_cogex/sources/indra_db/assembly.py
@@ -335,6 +335,7 @@ def belief_calc(refinements_graph: nx.DiGraph):
     be = BeliefEngine(refinements_graph=refinements_graph)
 
     # Load the source counts
+    logger.info("Loading source counts")
     with source_counts_fname.open("rb") as fh:
         source_counts = pickle.load(fh)
 

--- a/src/indra_cogex/sources/indra_db/assembly.py
+++ b/src/indra_cogex/sources/indra_db/assembly.py
@@ -386,7 +386,7 @@ def belief_calc(refinements_graph: nx.DiGraph):
             hashes, stmt_list = zip(*stmts)
             be.set_prior_probs(statements=stmt_list)
             for sh, st in zip(hashes, stmt_list):
-                belief_scores[sh] = stmt.belief
+                belief_scores[sh] = st.belief
 
     # Dump the belief scores
     with belief_scores_pkl_fname.open("wb") as fo:

--- a/src/indra_cogex/sources/indra_db/assembly.py
+++ b/src/indra_cogex/sources/indra_db/assembly.py
@@ -5,6 +5,7 @@ import math
 import json
 import pickle
 import itertools
+from pathlib import Path
 from typing import List, Set, Tuple, Optional
 
 import networkx as nx
@@ -301,7 +302,14 @@ def sample_unique_stmts(
     return stmts
 
 
-def belief_calc(refinements_graph: nx.DiGraph):
+def belief_calc(
+        refinements_graph: nx.DiGraph,
+        num_batches: int,
+        batch_size: int,
+        unique_stmts_path: Path = unique_stmts_fname,
+        belief_scores_pkl_path: Path = belief_scores_pkl_fname,
+        source_counts_path: Path = source_counts_fname,
+):
     # Belief Calculations
     """
     Belief calculation idea:
@@ -336,7 +344,7 @@ def belief_calc(refinements_graph: nx.DiGraph):
 
     # Load the source counts
     logger.info("Loading source counts")
-    with source_counts_fname.open("rb") as fh:
+    with source_counts_path.open("rb") as fh:
         source_counts = pickle.load(fh)
 
     # Store hash: belief score
@@ -373,7 +381,7 @@ def belief_calc(refinements_graph: nx.DiGraph):
             belief_scores[sh] = st.belief
 
     # Iterate over each unique statement
-    with gzip.open(unique_stmts_fname.as_posix(), "rt") as fh:
+    with gzip.open(unique_stmts_path.as_posix(), "rt") as fh:
         reader = csv.reader(fh, delimiter="\t")
 
         for _ in tqdm.tqdm(range(num_batches), desc="Calculating belief"):
@@ -396,7 +404,7 @@ def belief_calc(refinements_graph: nx.DiGraph):
             _add_belief_scores_for_batch(stmt_batch)
 
     # Dump the belief scores
-    with belief_scores_pkl_fname.open("wb") as fo:
+    with belief_scores_pkl_path.open("wb") as fo:
         pickle.dump(belief_scores, fo)
 
 

--- a/src/indra_cogex/sources/indra_db/assembly.py
+++ b/src/indra_cogex/sources/indra_db/assembly.py
@@ -360,8 +360,7 @@ def belief_calc(
 
         # If there are refinements, add them to the source counts
         if stmt_hash in refinements_graph.nodes():
-            refiner_hashes = nx.ancestors(G=refinements_graph,
-                                          source=stmt_hash)
+            refiner_hashes = nx.ancestors(refinements_graph, stmt_hash)
             for refiner_hash in refiner_hashes:
                 summed_source_counts += Counter(source_counts[refiner_hash])
 

--- a/src/indra_cogex/sources/indra_db/raw_export.py
+++ b/src/indra_cogex/sources/indra_db/raw_export.py
@@ -156,7 +156,7 @@ if __name__ == "__main__":
         ],
         "trips": ["STATIC", "2019Nov14", "2021Jan26"],
         "isi": ["20180503"],
-        "eidos": ["0.2.3-SNAPSHOT"],
+        "eidos": ["0.2.3-SNAPSHOT", "1.7.1-SNAPSHOT"],
         "mti": ["1.0"],
     }
 

--- a/tests/test_indra_db.py
+++ b/tests/test_indra_db.py
@@ -1,5 +1,15 @@
+import csv
+import gzip
+import json
+import pickle
+from pathlib import Path
+from collections import Counter
+
+import networkx as nx
+
 from indra.belief import BeliefEngine
 from indra.statements import Agent, Evidence, Activation
+from indra_cogex.sources.indra_db.assembly import belief_calc
 
 
 def test_unit_belief_calc():
@@ -19,3 +29,112 @@ def test_unit_belief_calc():
 
     assert activation.belief != 1
     assert activation.belief == 0.923
+
+
+def test_belief_calc():
+    activation1 = Activation(
+        Agent("A", location="nucleus"),
+        Agent("B", location="cytoplasm"),
+        evidence=[
+            Evidence(
+                source_api="reach",
+                text="A activates B in vitro in a dose-dependent manner.")
+        ],
+    )
+    hash1 = activation1.get_hash()
+    activation2 = Activation(
+        Agent("A", location="nucleus"),
+        Agent("B"),
+        evidence=[
+            Evidence(source_api="reach", text="A activates B in vitro.")
+        ],
+    )
+    hash2 = activation2.get_hash()
+    activation3 = Activation(
+        Agent("A"),
+        Agent("B"),
+        evidence=[Evidence(source_api="reach", text="A activates B.")],
+    )
+    hash3 = activation3.get_hash()
+
+    # Sanity check
+    assert hash1 != hash2 != hash3
+
+    stmt_list = [(hash1, activation1), (hash2, activation2), (hash3, activation3)]
+
+    # Dump the statements to a file
+    test_statements_tsv_gz = Path(__file__).parent / "test_statements.tsv.gz"
+    with gzip.open(test_statements_tsv_gz, "wt") as f:
+        csv_writer = csv.writer(f, delimiter="\t")
+        csv_writer.writerows(
+            (sh, json.dumps(st.to_json())) for sh, st in stmt_list
+        )
+
+    source_counts = {
+        hash1: {"reach": 1},
+        hash2: {"reach": 1},
+        hash3: {"reach": 1},
+    }
+    test_source_counts_pkl = Path(__file__).parent / "test_source_counts.pkl"
+    with open(test_source_counts_pkl, "wb") as f:
+        pickle.dump(source_counts, f)
+
+    # Create support: activation1 -> activation2 -> activation3 in a
+    # refinement graph
+    refinements = {(hash1, hash2), (hash2, hash3)}
+    refinement_graph = nx.DiGraph()
+    refinement_graph.add_edges_from(refinements)
+    assert nx.ancestors(refinement_graph, hash1) == set()
+    assert nx.ancestors(refinement_graph, hash2) == {hash1}
+    assert nx.ancestors(refinement_graph, hash3) == {hash1, hash2}
+
+    # Run the belief calculation function
+    test_belief_path = Path(__file__).parent / "test_belief_path.pkl"
+    belief_calc(
+        refinements_graph=refinement_graph,
+        num_batches=1,
+        batch_size=len(stmt_list),
+        unique_stmts_path=test_statements_tsv_gz,
+        belief_scores_pkl_path=test_belief_path,
+        source_counts_path=test_source_counts_pkl,
+    )
+
+    # Calculate the belief scores: Add evidence of supporting statements to the
+    # evidence of the supported statement then calculate the prior belief
+    belief_engine = BeliefEngine(refinements_graph=refinement_graph)
+    to_calc_list = []
+    local_beliefs = {}
+    for st_hash, stmt in stmt_list:
+        # Sum belief score of ancestors
+        summed_src_count = Counter(source_counts[st_hash])
+
+        if st_hash in refinement_graph.nodes:
+            for anc_hash in nx.ancestors(refinement_graph, st_hash):
+                summed_src_count += Counter(source_counts[anc_hash])
+
+        ev_list_this_stmt = []
+        for source, count in summed_src_count.items():
+            for _ in range(count):
+                ev_list_this_stmt.append(Evidence(source_api=source))
+
+        stmt.evidence = ev_list_this_stmt
+        to_calc_list.append((st_hash, stmt))
+
+    hashes, stmts = zip(*to_calc_list)
+    belief_engine.set_prior_probs(stmts)
+    for st_hash2, stmt2 in zip(hashes, stmts):
+        local_beliefs[st_hash2] = stmt2.belief
+
+    # Load the belief scores
+    with open(test_belief_path, "rb") as f:
+        belief_dict = pickle.load(f)
+
+    # Check that the belief scores are correct
+    assert all(
+        local_beliefs[st_hash] == belief_dict[st_hash]
+        for st_hash in belief_dict
+    )
+
+    assert len(stmts[2].evidence) == 3
+    assert all(ev.source_api == 'reach' for ev in stmts[2].evidence)
+    assert belief_dict[hash3] == 0.923

--- a/tests/test_indra_db.py
+++ b/tests/test_indra_db.py
@@ -1,0 +1,21 @@
+from indra.belief import BeliefEngine
+from indra.statements import Agent, Evidence, Activation
+
+
+def test_unit_belief_calc():
+    activation = Activation(
+        Agent("A"),
+        Agent("B"),
+        evidence=[Evidence(source_api="reach") for _ in range(3)],
+    )
+
+    # Test that the belief score is calculated correctly
+    assert activation.belief == 1
+
+    # Set up default Belief Engine
+    belief_engine = BeliefEngine()
+
+    belief_engine.set_prior_probs([activation])
+
+    assert activation.belief != 1
+    assert activation.belief == 0.923


### PR DESCRIPTION
This PR handles a bug in the belief score calculation where the wrong variable was used to assign the final score, resulting in only the last calculated belief in a batch of statements being assigned to all statements in the batch.

The bug is fixed and the affected code and its surrounding code is reorganized to make it more clear.

The latest eidos reader version is also added in this PR.