### PR TITLE
Index id property

### DIFF
--- a/src/indra_cogex/indexing/__init__.py
+++ b/src/indra_cogex/indexing/__init__.py
@@ -41,7 +41,7 @@ def index_nodes_on_id(client: Neo4jClient, exist_ok: bool = False):
 
 
 def index_evidence_on_stmt_hash(client: Neo4jClient, exist_ok: bool = False):
-    """Index all Evidence nodes on the statement hash
+    """Index all Evidence nodes on the stmt_hash property
 
     Parameters
     ----------
@@ -59,7 +59,7 @@ def index_evidence_on_stmt_hash(client: Neo4jClient, exist_ok: bool = False):
 
 
 def index_indra_rel_on_stmt_hash(client: Neo4jClient):
-    """Index all indra_rel relationships on stmt_hash
+    """Index all indra_rel relationships on stmt_hash property
 
     Parameters
     ----------

--- a/src/indra_cogex/indexing/__init__.py
+++ b/src/indra_cogex/indexing/__init__.py
@@ -1,7 +1,43 @@
 # -*- coding: utf-8 -*-
 
 """A collection of functions for indexing on the database."""
+import time
+
+from tqdm import tqdm
+
 from indra_cogex.client.neo4j_client import Neo4jClient
+
+
+def index_nodes_on_id(client: Neo4jClient, exist_ok: bool = False):
+    """Index all nodes on the id property
+
+    Parameters
+    ----------
+    client :
+        Neo4jClient instance to the graph database to be indexed
+    exist_ok :
+        If False, raise an exception if the index already exists. Default: False.
+    """
+    # A label has to be provided to build the index, so we have to loop over
+    # all labels and build the index for each one.
+    for label in tqdm(
+        [
+            "Evidence",
+            "Publication",
+            "BioEntity",
+            "ClinicalTrial",
+            "Patent",
+            "ResearchProject",
+        ]
+    ):
+        client.create_single_property_node_index(
+            index_name=f"node_id_{label.lower()}",
+            label=label,
+            property_name="id",
+            exist_ok=exist_ok,
+        )
+        # Wait a bit just to be on the safe side
+        time.sleep(0.25)
 
 
 def index_evidence_on_stmt_hash(client: Neo4jClient, exist_ok: bool = False):

--- a/src/indra_cogex/indexing/cli.py
+++ b/src/indra_cogex/indexing/cli.py
@@ -14,6 +14,11 @@ import click
     help="Build all indexes",
 )
 @click.option(
+    "--index-nodes",
+    is_flag=True,
+    help="Index all nodes on the id property.",
+)
+@click.option(
     "--index-evidence-nodes",
     is_flag=True,
     help="Index the Evidence nodes on the stmt_hash property.",
@@ -31,6 +36,7 @@ import click
 )
 def main(
     all_: bool = False,
+    index_nodes: bool = False,
     index_evidence_nodes: bool = False,
     index_indra_relations: bool = False,
     exist_ok: bool = False,
@@ -39,6 +45,11 @@ def main(
 ):
     """Build indexes on the database."""
     client = _get_client(url, auth)
+    if all_ or index_nodes:
+        from . import index_nodes_on_id
+
+        click.secho("Indexing all nodes on the id property.", fg="green")
+        index_nodes_on_id(client, exist_ok=exist_ok)
     if all_ or index_evidence_nodes:
         from . import index_evidence_on_stmt_hash
 


### PR DESCRIPTION
This PR solves a longstanding mystery of slow lookup when matching against the `id` property of nodes. While it appears that the _internal_ id, accessed via `id(n)` is indexed, the _node property_ `id` was not.

The index building for the id property is added as a separate function to the indexing module and is included when running the import script, `import.sh`.