### PR TITLE
Get statements from PubMeds

### DIFF
--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -924,7 +924,7 @@ def get_stmts_for_paper(
 
 @autoclient()
 def get_stmts_for_pubmeds(
-    pubmeds: List[str], *, client: Neo4jClient, **kwargs
+    pubmeds: List[Union[str, int]], *, client: Neo4jClient, **kwargs
 ) -> List[Statement]:
     """Return the statements with evidence from the given PubMed ID.
 
@@ -938,7 +938,16 @@ def get_stmts_for_pubmeds(
     Returns
     -------
     :
-        The statements for the given PubMed ID.
+        The statements for the given PubMed identifiers.
+
+    Example
+    -------
+    .. code-block::
+
+        from indra_cogex.client.queries import get_stmts_for_pubmeds
+
+        pubmeds = [20861832, 19503834]
+        stmts = get_stmts_for_pubmeds(pubmeds)
     """
     pubmeds = sorted(f"pubmed:{pubmed}" for pubmed in pubmeds)
     hash_query = f"""\

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -313,6 +313,16 @@ def test_get_stmts_for_pmid():
 
 
 @pytest.mark.nonpublic
+def test_get_stmts_for_pmid():
+    # Two queries: first evidences, then the statements
+    client = _get_client()
+    pubmeds = ["14898026"]
+    stmts = get_stmts_for_pubmeds(pubmeds, client=client)
+    assert stmts
+    assert isinstance(stmts[0], Statement)
+
+
+@pytest.mark.nonpublic
 def test_get_stmts_for_mesh_id_w_children():
     # Two queries:
     # 1. evidences for publications with pmid having mesh annotation


### PR DESCRIPTION
This PR adds a more convenient function than `get_stmts_for_paper` that allows bulk lookup of statements from a publication list. Example usage:

```python
from indra_cogex.client.queries import get_stmts_for_pubmeds

pubmeds = [20861832, 19503834]  # also works on strings
stmts = get_stmts_for_pubmeds(pubmeds)
```