### PR TITLE
Use more efficient method to get curations

### DIFF
--- a/src/indra_cogex/apps/curator/curator_blueprint.py
+++ b/src/indra_cogex/apps/curator/curator_blueprint.py
@@ -106,7 +106,7 @@ def _enrich_render_statements(
     curations: Optional[List[Mapping[str, Any]]] = None,
 ) -> Response:
     if curations is None:
-        curations = curation_cache.get_curations()
+        curations = curation_cache.get_curation_cache()
     stmts = remove_curated_statements(stmts, curations=curations)
     stmts = stmts[: proxies.limit]
 
@@ -186,7 +186,7 @@ def _curate_mesh_helper(
 ) -> Response:
     if curations is None:
         logger.info("Getting curations")
-        curations = curation_cache.get_curations()
+        curations = curation_cache.get_curation_cache()
         logger.debug(f"Got {len(curations)} curations")
 
     logger.info(f"Getting statements for mesh:{term}")
@@ -274,7 +274,7 @@ def _render_evidence_counts(
     filter_curated: bool = True,
     description: Optional[str] = None,
 ) -> Response:
-    curations = curation_cache.get_curations()
+    curations = curation_cache.get_curation_cache()
     logger.debug(f"loaded {len(curations):,} curations")
     evidence_counts = {
         stmt_hash: sum(source_counts.values())
@@ -570,7 +570,7 @@ def _curate_paper(
         (prefix, identifier), return_evidence_counts=True
     )
     if curations is None:
-        curations = curation_cache.get_curations()
+        curations = curation_cache.get_curation_cache()
     if filter_curated:
         stmts = remove_curated_evidences(stmts, curations=curations)
     return render_statements(

--- a/src/indra_cogex/apps/curator/utils.py
+++ b/src/indra_cogex/apps/curator/utils.py
@@ -36,7 +36,7 @@ def iterate_conflicts(
 ) -> Iterable[Tuple[int, int, bool]]:
     """Iterate hashes of statements and their resolution status."""
     if curations is None:
-        curations = curation_cache.get_curations()
+        curations = curation_cache.get_curation_cache()
     stmt_hash_to_counter = _group_curations(curations)
     query = f"""\
         MATCH (:BioEntity)-[r:indra_rel]->(:BioEntity)

--- a/src/indra_cogex/client/curation.py
+++ b/src/indra_cogex/client/curation.py
@@ -58,8 +58,8 @@ def _get_text(stmt: Statement) -> Optional[str]:
 
 
 def _get_curated_statement_hashes() -> Set[int]:
-    stmt_jsons = curation_cache.get_curations()
-    return {curation["pa_hash"] for curation in stmt_jsons}
+    curation_list = curation_cache.get_curation_cache()
+    return {curation["pa_hash"] for curation in curation_list}
 
 
 def get_prioritized_stmt_hashes(stmts: Iterable[Statement]) -> List[int]:

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -83,12 +83,12 @@ def test_is_go_term_for_gene():
 @pytest.mark.nonpublic
 def test_get_trials_for_drug():
     client = _get_client()
-    drug = ("CHEBI", "CHEBI:27690")
+    drug = ("MESH", "C000489")
     trials = get_trials_for_drug(drug, client=client)
     assert trials
     assert isinstance(trials[0], Node)
     assert trials[0].db_ns == "CLINICALTRIALS"
-    assert ("CLINICALTRIALS", "NCT02703220") in {t.grounding() for t in trials}
+    assert ("CLINICALTRIALS", "NCT00000674") in {t.grounding() for t in trials}
 
 
 @pytest.mark.nonpublic


### PR DESCRIPTION
This PR updates which method is used to get curations in several places to use a more efficient method of the CurationCache class.