### PR TITLE
Fix API Docs link

### DIFF
--- a/src/indra_cogex/apps/templates/base.html
+++ b/src/indra_cogex/apps/templates/base.html
@@ -103,7 +103,9 @@
                     No API available
                 {% endif %}
                 #}
-                <a class="nav-link" href="{{ config.get('APPLICATION_ROOT', '') }}/apidocs">API Docs</a>
+                {% set apidocs_url = config.get('APPLICATION_ROOT', '') + '/apidocs' %}
+                {% set apidocs_url = apidocs_url.replace('//', '/') %}
+                <a class="nav-link" href="{{ apidocs_url }}">API Docs</a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="#about">About</a>


### PR DESCRIPTION
This PR fixes a bug in the linkout to the API Docs on the landing page.

The issue was that when the `ROOT_PATH` environment variable was unset, Flask's `APPLICATION_ROOT` is set to its default `/`, which is all good, but the logic for setting the path to the API Docs made _that_ path become `//apidocs` which is interpreted as `https://apidocs` rather than `https://discovery.indra.bio//apidocs`. This PR updates the logic to replace any `//` with `/`, so that any path set to the apidocs becomes relative to the domain root.