### PR TITLE
Simplify DepMep version getting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ keywords =
 [options]
 install_requires =
     indra @ git+https://github.com/gyorilab/indra.git
-    pysb @ git+https://github.com/pysb/pysb.git
     neo4j>=6
     click
     setuptools<81

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ keywords =
 [options]
 install_requires =
     indra @ git+https://github.com/gyorilab/indra.git
+    pysb @ git+https://github.com/pysb/pysb.git
     neo4j>=6
     click
     setuptools<81

--- a/src/indra_cogex/sources/depmap/download_data.py
+++ b/src/indra_cogex/sources/depmap/download_data.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 from functools import lru_cache
 
 import requests
@@ -67,7 +68,9 @@ MITOCARTA_NAME = "Human.MitoCarta3.0.xls"  # Rarely updates, see https://www.bro
 MODEL_INFO_NAME = "Model.csv"  # To get mapping from model name to CCLE Name
 CRISPR_NAME = "CRISPRGeneEffect.csv"  # CRISPr data
 RNAI_NAME = "D2_combined_gene_dep_scores.csv"  # RNAi data
-DEPMAP_RELEASE = get_latest_depmap().split()[-1].lower()  # e.g., "21q4"
+# Avoid contacting the DepMap API at import time. The latest release is still
+# resolved when download URLs are requested.
+DEPMAP_RELEASE = os.environ.get("DEPMAP_RELEASE", "latest")
 DEPMAP_RELEASE_MODULE = SUBMODULE.module(DEPMAP_RELEASE)
 
 

--- a/src/indra_cogex/sources/depmap/download_data.py
+++ b/src/indra_cogex/sources/depmap/download_data.py
@@ -70,6 +70,7 @@ CRISPR_NAME = "CRISPRGeneEffect.csv"  # CRISPr data
 RNAI_NAME = "D2_combined_gene_dep_scores.csv"  # RNAi data
 # Avoid contacting the DepMap API at import time. The latest release is still
 # resolved when download URLs are requested.
+# DEPMAP_RELEASE = get_latest_depmap().split()[-1].lower()  # e.g., "21q4"
 DEPMAP_RELEASE = os.environ.get("DEPMAP_RELEASE", "latest")
 DEPMAP_RELEASE_MODULE = SUBMODULE.module(DEPMAP_RELEASE)
 


### PR DESCRIPTION
~This PR uses the latest pysb (installed from master on github) to resolve an issue relating to python version constraints (see https://github.com/pysb/pysb/pull/619).~

A fix that skips import of variables that execute a call to intermittently failing rest API in the depmap source submodule is also added.

_Work done by @prasham21 and cherry-picked by @kkaris._